### PR TITLE
Update qos.rst after first UI release

### DIFF
--- a/qos.rst
+++ b/qos.rst
@@ -30,6 +30,10 @@ To ensure resilience against service fluctuations, it is advisable to maintain a
 Advanced Configuration
 ====================
 
+QoS relies on an eBPF (Extended Berkeley Packet Filter) based classifier to set Differentiated Services Code Point (DSCP) fields in packets. This classification helps prioritize and manage network traffic efficiently.
+To maximize efficiency, QoS operates in the kernel space using eBPF technology. This ensures minimal overhead and minimal impact on system performance.
+In addition to IP and port-based rules, QoS allows you to define traffic rules based on DNS names, providing granular control over how traffic is classified and treated.
+
 While Qosify works effectively without extensive configuration, it can be further optimized by setting bandwidth limits and rules.
 Fine-tuning QoS parameters can result in even better network performance.
 

--- a/qos.rst
+++ b/qos.rst
@@ -2,67 +2,56 @@
 Quality of Service (QoS)
 =========================
 
-.. warning::
-
-   This feature is still under development and does not have a user interface yet. It can currently only be configured through the command line.
-
-NethSecuirty QoS uses Qosify to optimize network's performance.
-QoS is based on the CAKE (Common Applications Kept Enhanced) queuing discipline for Linux.
-It provides Active Queue Management (AQM) and Flow Queuing (FQ) capabilities to help ensure that your network resources are used efficiently and fairly.
+NethSecurity QoS provides Active Queue Management (AQM) and Flow Queuing (FQ) capabilities to help ensure that your network resources are used efficiently and fairly.
 
 Operating principles
 ====================
 
-`Qosify <https://github.com/openwrt/qosify>`_ is designed to make the best use of available bandwidth, without imposing strict limits or shaping traffic by default.
+NethSecurity QoS is designed to make the best use of available bandwidth, without imposing strict limits or shaping traffic by default.
 It operates on the following principles:
 
-- *Bandwidth usage*: Qosify strives to utilize the available bandwidth to its fullest potential. By default, it does not impose strict bandwidth
-  limitations on your network.
+- *Bandwidth usage*: QoS strives to utilize the available bandwidth to its fullest potential. By default, it does not impose strict bandwidth limitations on your network.
   Instead, it dynamically adjusts to network conditions, ensuring that unused bandwidth is efficiently utilized.
 
-- *Flow management*: Qosify actively manages network flows to prevent any single client or application from monopolizing the available bandwidth.
+- *Flow management*: QoS actively manages network flows to prevent any single client or application from monopolizing the available bandwidth.
   This ensures fair and equitable access to network resources for all users.
 
-QoS relies on an eBPF (Extended Berkeley Packet Filter) based classifier to set Differentiated Services Code Point (DSCP) fields in packets. This classification helps prioritize and manage network traffic efficiently.
-To maximize efficiency, QoS operates in the kernel space using eBPF technology. This ensures minimal overhead and minimal impact on system performance.
-In addition to IP and port-based rules, QoS allows you to define traffic rules based on DNS names, providing granular control over how traffic is classified and treated.
+Configuration
+=============
 
-QoS can temporarily reduce the priority of a flow if it generates a significant amount of traffic, which is configurable.
-For example, a flow might be temporarily shifted to the "Bulk" priority if it sends a high number of packets within a short time.
-QoS can also prioritize small packets to ensure low-latency transmission of time-sensitive data.
+Bandwidth management is handled dynamically and automatically by the system. Configuration is straightforward, involving specifying upload and download bandwidth values for each interface under QoS. 
+
+While QoS can be set up on any interface, it typically functions optimally on WAN-type interfaces, aligning upload and download data with connectivity parameters.
+
+To ensure resilience against service fluctuations, it is advisable to maintain a safety margin by configuring these parameters 10% lower than the measured values
+
+
+
+Advanced Configuration
+====================
+
+While Qosify works effectively without extensive configuration, it can be further optimized by setting bandwidth limits and rules.
+Fine-tuning QoS parameters can result in even better network performance.
+
+The modifications to the standard behavior however can be useful in very limited scenarios, for which, currently, it is only possible to act directly through the character console.
+
 
 Priority classes
 ----------------
 
-CAKE uses four classes of priority, as defined by the DiffServ (Differentiated Services) model:
+The QoS uses four classes of priority, each class can use a maximum percentage of bandwidth defined by its threshold.
 
 - **Bulk (CS1, LE in kernel v5.9+):** This class is designed for low-priority traffic, with a 6.25% threshold.
 - **Best Effort (General):** This class has a 100% threshold and is used for typical, non-prioritized traffic.
 - **Video (AF4x, AF3x, CS3, AF2x, CS2, TOS4, TOS1):** Video traffic falls under this class, with a 50% threshold.
 - **Voice (CS7, CS6, EF, VA, CS5, CS4):** Voice traffic is given the highest priority, with a 25% threshold.
 
-Configuration
-=============
 
-.. highlight:: bash
+QoS can temporarily reduce the priority of a flow if it generates a significant amount of traffic, which is configurable.
+For example, a flow might be temporarily shifted to the "Bulk" priority if it sends a high number of packets within a short time.
+QoS can also prioritize small packets to ensure low-latency transmission of time-sensitive data.
 
-While Qosify works effectively without extensive configuration, it can be further optimized by setting bandwidth limits and rules.
-Fine-tuning QoS parameters can result in even better network performance.
-
-To enable qosify on the wan interface, execute: ::
-
-  uci set qosify.wan.disabled=0
-
-To set bandwidth (30mbit download and 10 mbit upload): ::
-
-  uci set qosify.wan.bandwidth_down=30mbit
-  uci set qosify.wan.bandwidth_up=10mbit
-
-Apply config and restart qosify: ::
-
-  uci commit qosify
-  /etc/init.d/qosify restart
- 
+In addition to IP and port-based rules, QoS allows you to define traffic rules based on DNS names, providing granular control over how traffic is classified and treated.
 
 To override DSCP classification, create a file ``/etc/qosify/10-custom.conf`` with mappings:
 Each line has two whitespace separated fields, match and dscp.

--- a/qos.rst
+++ b/qos.rst
@@ -21,7 +21,7 @@ Configuration
 
 Bandwidth management is handled dynamically and automatically by the system. Configuration is straightforward, involving specifying upload and download bandwidth values for each interface under QoS. 
 
-While QoS can be set up on any interface, it typically functions optimally on WAN-type interfaces, aligning upload and download data with connectivity parameters.
+While QoS can be set up on any interface, it typically functions optimally on WAN-type interfaces, setting upload and download speeds to the internet connection data rates.
 
 To ensure resilience against service fluctuations, it is advisable to maintain a safety margin by configuring these parameters 10% lower than the measured values
 

--- a/qos.rst
+++ b/qos.rst
@@ -33,7 +33,7 @@ Advanced Configuration
 While Qosify works effectively without extensive configuration, it can be further optimized by setting bandwidth limits and rules.
 Fine-tuning QoS parameters can result in even better network performance.
 
-The modifications to the standard behavior however can be useful in very limited scenarios, for which, currently, it is only possible to act directly through the character console.
+The modifications to the standard behavior however can be useful in very limited scenarios, for which, currently, it is only possible to act directly through the command line.
 
 
 Priority classes

--- a/qos.rst
+++ b/qos.rst
@@ -39,7 +39,7 @@ The modifications to the standard behavior however can be useful in very limited
 Priority classes
 ----------------
 
-The QoS uses four classes of priority, each class can use a maximum percentage of bandwidth defined by its threshold.
+QoS uses four classes of priority, each class can use a maximum percentage of bandwidth defined by its threshold.
 
 - **Bulk (CS1, LE in kernel v5.9+):** This class is designed for low-priority traffic, with a 6.25% threshold.
 - **Best Effort (General):** This class has a 100% threshold and is used for typical, non-prioritized traffic.


### PR DESCRIPTION
Update qos.rst after first UI release
I modified the document thinking of the sysadmin as the recipient, thus removing some interesting but unnecessary technical information while still indicating the instructions for any changes from the console at the end