### PR TITLE
DHCP and DNS input rule for guest zone 

### DIFF
--- a/zones_and_policies.rst
+++ b/zones_and_policies.rst
@@ -66,6 +66,9 @@ To create a Guest zone, follow these steps:
 - select ``Drop`` for both ``Traffic to firewall`` and ``Traffic for the same zone`` fields
 - click on the ``Save`` button and apply the changes
 
+.. note::
+
+  If the firewall is intended to provide ``DHCP`` and ``DNS`` services, create a firewall ``input rule`` allowing traffic on ports ``53 TCP/UDP (DNS)`` as well port ``68 UDP (DHCP)`` for the ``Guest`` zone. If these services are not required or provided by another device in this network, the corresponding ports can remain blocked.
 
 DMZ zone (orange)
 ^^^^^^^^^^^^^^^^^

--- a/zones_and_policies.rst
+++ b/zones_and_policies.rst
@@ -67,8 +67,8 @@ To create a Guest zone, follow these steps:
 - click on the ``Save`` button and apply the changes
 
 .. note::
-
-  If the firewall is intended to provide ``DHCP`` and ``DNS`` services, create a firewall ``input rule`` allowing traffic on ports ``53 TCP/UDP (DNS)`` as well port ``68 UDP (DHCP)`` for the ``Guest`` zone. If these services are not required or provided by another device in this network, the corresponding ports can remain blocked.
+  If the firewall is intended to provide ``DHCP`` and ``DNS`` services, create a firewall ``input rule`` allowing traffic on ports ``53 TCP/UDP (DNS)`` as well port ``68 UDP (DHCP)`` for the ``Guest`` zone.
+  If these services are not required or provided by another device in this network, the corresponding ports can remain blocked.
 
 DMZ zone (orange)
 ^^^^^^^^^^^^^^^^^

--- a/zones_and_policies.rst
+++ b/zones_and_policies.rst
@@ -67,7 +67,7 @@ To create a Guest zone, follow these steps:
 - click on the ``Save`` button and apply the changes
 
 .. note::
-  If the firewall is intended to provide ``DHCP`` and ``DNS`` services, create a firewall ``input rule`` allowing traffic on ports ``53 TCP/UDP (DNS)`` as well port ``68 UDP (DHCP)`` for the ``Guest`` zone.
+  If the firewall is intended to provide ``DHCP`` and ``DNS`` services, create a firewall ``input rule`` allowing traffic on ports ``53 TCP/UDP (DNS)`` as well port ``67 UDP (DHCP)`` for the ``Guest`` zone.
   If these services are not required or provided by another device in this network, the corresponding ports can remain blocked.
 
 DMZ zone (orange)


### PR DESCRIPTION
If the firewall is intended to provide DHCP and DNS services for the Guest zone, input rules must be configured to allow traffic on the following ports:

53 TCP/UDP for DNS
67 UDP for DHCP