### PR TITLE
fix(build): add python env support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,1 @@
 _build/
-bin/
-lib/
-lib64/

--- a/README.rst
+++ b/README.rst
@@ -119,10 +119,13 @@ On Fedora 37 or later use: ::
 
   sudo dnf install python3-sphinx python3-pip make
 
-Then clone the repository, change into the cloned directory and install all required extra modules ::
+The local build uses a Python virtual environment.
+First clone the repository, change into the cloned directory and setup the virtual env ::
 
   git clone https://github.com/NethServer/nethsecurity-docs.git
   cd nethsecurity-docs
+  python3 -m venv venv
+  source venv/bin/activate
   pip install -r requirements.txt
 
 Finally, build the doc: ::

--- a/conf.py
+++ b/conf.py
@@ -39,7 +39,7 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'README.rst', "lib", "lib64"]
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'README.rst', "venv"]
 
 # -- Options for translations ------------------------------------------------
 locale_dirs = ['locale/']


### PR DESCRIPTION
An update to boto 1.35 broke the build.
Make sure to always use a pyevn locally.

Please note that changes to .gitignore and conf.py are a partially revert of the previous commit: I wrongly pushed a partial work for virtual env.