### PR TITLE
fix: added CIDR references where needed

### DIFF
--- a/dpi_filter.rst
+++ b/dpi_filter.rst
@@ -55,7 +55,7 @@ Exceptions
 DPI exclusion allows for the exclusion of specific network addresses, such as the gateway or other critical infrastructure, preventing them from being blocked.
 
 To add a new exception, click the ``Add exception`` button.
-Enter the ``IP address`` that should be exempted from the filter.
+Enter the ``IP address or CIDR`` that should be exempted from the filter.
 You can include a description explaining the reason for the exclusion.
 
 Each exception can be enabled or disabled as desired.

--- a/ips.rst
+++ b/ips.rst
@@ -89,7 +89,7 @@ To do so, browse to the `Filter bypass` tab and press the :guilabel:`Add bypass`
 add the bypass rule based of the source or destination IP address with the following fields:
 
 - ``Address type``: if the ip provided is IPv4 or IPv6
-- ``IP address``: the IP address to bypass
+- ``IP address``: the IP address or CIDR to bypass
 - ``Direction``: if the bypass is for the source or destination IP address
 - ``Description``: a description of the bypass rule, it is optional and can be omitted
 


### PR DESCRIPTION
Due to:
- https://github.com/NethServer/nethsecurity/pull/1275
- https://github.com/NethServer/nethsecurity-ui/pull/587

CIDRs are now possible in snort exclusions and netifyd exclusions
