### PR TITLE
Removed "FlashStart Combined assignment" section

### DIFF
--- a/flashstart.rst
+++ b/flashstart.rst
@@ -187,9 +187,6 @@ FlashStart Pro Plus extends functionality with support for multiple independent 
   - **Active Directory users:**  
     If the FlashStart AD connector is installed, profiles can be assigned to AD users directly, eliminating the need to rely on IP addresses.
 
-- **Combined assignment (objects + users):**  
-  It is possible to use both methods in parallel.In case of conflicts, firewall object assignments take precedence over user-based assignments.
-
 .. note::
 
   Although no known bugs have been reported at this time, the Pro Plus feature is currently released as a **Beta**. We recommend testing it in a non-critical environment before deploying it in production.


### PR DESCRIPTION
At the moment the filter’s conflict behavior is predictable but complex. We’re temporarily removing the section, planning to reintroduce it after simplifying it.
