### PR TITLE
fix(flashtart): no more need for DNS option on DHCP server

### DIFF
--- a/flashstart.rst
+++ b/flashstart.rst
@@ -28,10 +28,6 @@ It basically links 2 components : filter configuration and network configuration
 
 .. warning::
 
-  If you are using the DHCP service on NethSecurity, please note that FlashStart integration requires explicitly
-  specifying the DNS server through DHCP options.Go to the DHCP section, under Advanced Settings, and add the following
-  option: 6:dns-server,<YOUR-USUAL-DNS-SERVER>. This ensures that clients receive the correct DNS server via DHCP. In
-  this field, enter the DNS server typically used in your network, usually the IP address of the NethSecurity interface.
   Do not manually specify the IP addresses of the FlashStart DNS servers, as they are automatically managed by the
   integration.
 


### PR DESCRIPTION
Removed information about forced DNS server in the DHCP to stick with this improvement: https://github.com/NethServer/nethsecurity/issues/1287