### PR TITLE
docs: extra packages preserved during image upgrade

### DIFF
--- a/backup.rst
+++ b/backup.rst
@@ -38,7 +38,7 @@ After the restore the system will be rebooted.
 
 .. note::
    Starting from version 8.7.2 of NethSecurity, extra packages are preserved during system upgrades.
-   For earlier versions and for additional informations please refer to the following documentation :ref:`restore_extra_packages-section`.
+   For earlier versions and for additional information, refer to this documentation: :ref:`restore_extra_packages-section`.
 
 Machines with a subscription
 ============================

--- a/backup.rst
+++ b/backup.rst
@@ -36,7 +36,9 @@ If the backup is encrypted, enter the passphrase, and finally, click the :guilab
 
 After the restore the system will be rebooted.
 
-If you have installed extra packages, you can restore them by following the instructions in the :ref:`restore_extra_packages-section`.
+.. note::
+   Starting from version 8.7.2 of NethSecurity, extra packages are preserved during system upgrades.
+   For earlier versions, please refer to the following documentation to restore extra packages after an upgrade :ref:`restore_extra_packages-section`.
 
 Machines with a subscription
 ============================

--- a/backup.rst
+++ b/backup.rst
@@ -38,7 +38,7 @@ After the restore the system will be rebooted.
 
 .. note::
    Starting from version 8.7.2 of NethSecurity, extra packages are preserved during system upgrades.
-   For earlier versions, please refer to the following documentation to restore extra packages after an upgrade :ref:`restore_extra_packages-section`.
+   For earlier versions and for additional informations please refer to the following documentation :ref:`restore_extra_packages-section`.
 
 Machines with a subscription
 ============================

--- a/backup.rst
+++ b/backup.rst
@@ -37,7 +37,7 @@ If the backup is encrypted, enter the passphrase, and finally, click the :guilab
 After the restore the system will be rebooted.
 
 .. note::
-   Starting from version 8.7.2 of NethSecurity, extra packages are preserved during system upgrades.
+   Starting from version 8.7.2, extra packages are automatically reinstalled after system upgrade.
    For earlier versions and for additional information, refer to this documentation: :ref:`restore_extra_packages-section`.
 
 Machines with a subscription

--- a/install.rst
+++ b/install.rst
@@ -148,7 +148,7 @@ The QEMU guest agent will be available on the virtual machine and automatically 
 
 .. note::
    Starting from version 8.7.2 of NethSecurity, extra packages are preserved during system upgrades.
-   For earlier versions, please refer to the following documentation to restore extra packages after an upgrade :ref:`restore_extra_packages-section`.
+   For earlier versions and for additional information, refer to this documentation: :ref:`restore_extra_packages-section`.
 
 Install on VMWare
 -----------------

--- a/install.rst
+++ b/install.rst
@@ -147,7 +147,7 @@ After the installation, start the service: ::
 The QEMU guest agent will be available on the virtual machine and automatically started at boot.
 
 .. note::
-   Starting from version 8.7.2 of NethSecurity, extra packages are preserved during system upgrades.
+   Starting from version 8.7.2, extra packages are automatically reinstalled after system upgrade.
    For earlier versions and for additional information, refer to this documentation: :ref:`restore_extra_packages-section`.
 
 Install on VMWare

--- a/install.rst
+++ b/install.rst
@@ -146,8 +146,9 @@ After the installation, start the service: ::
 
 The QEMU guest agent will be available on the virtual machine and automatically started at boot.
 
-Please note that after an image upgrade the QEMU guest agent will be removed and you will need to reinstall it.
-See :ref:`restore_extra_packages-section` for more info.
+.. note::
+   Starting from version 8.7.2 of NethSecurity, extra packages are preserved during system upgrades.
+   For earlier versions, please refer to the following documentation to restore extra packages after an upgrade :ref:`restore_extra_packages-section`.
 
 Install on VMWare
 -----------------

--- a/package
+++ b/package
@@ -44,7 +44,7 @@ Install the required packages::
     opkg install nut-server nut-upsc nut-upsmon nut-upscmd
 
 .. note::
-   Starting from version 8.7.2 of NethSecurity, extra packages are preserved during system upgrades.
+   Starting from version 8.7.2, extra packages are automatically reinstalled after system upgrade.
    For earlier versions and for additional information, refer to this documentation: :ref:`restore_extra_packages-section`.
 
 Step 2: setup the appropriate driver

--- a/package
+++ b/package
@@ -45,7 +45,7 @@ Install the required packages::
 
 .. note::
    Starting from version 8.7.2 of NethSecurity, extra packages are preserved during system upgrades.
-   For earlier versions, please refer to the following documentation to restore extra packages after an upgrade :ref:`restore_extra_packages-section`.
+   For earlier versions and for additional information, refer to this documentation: :ref:`restore_extra_packages-section`.
 
 Step 2: setup the appropriate driver
 ------------------------------------

--- a/remote_access.rst
+++ b/remote_access.rst
@@ -307,5 +307,5 @@ Two packages are provided for installation, covering the vast majority of adapte
     Aug  6 08:08:17 nsec8 kernel: [ 2346.550401] usb 1-6: pl2303 converter now attached to ttyUSB0
 
 .. note::
-   Starting from version 8.7.2 of NethSecurity, extra packages are preserved during system upgrades.
+   Starting from version 8.7.2, extra packages are automatically reinstalled after system upgrade.
    For earlier versions and for additional information, refer to this documentation: :ref:`restore_extra_packages-section`.

--- a/remote_access.rst
+++ b/remote_access.rst
@@ -308,5 +308,4 @@ Two packages are provided for installation, covering the vast majority of adapte
 
 .. note::
    Starting from version 8.7.2 of NethSecurity, extra packages are preserved during system upgrades.
-   For earlier versions, please refer to the following documentation to restore extra packages after an upgrade :ref:`restore_extra_packages-section`.
-
+   For earlier versions and for additional information, refer to this documentation: :ref:`restore_extra_packages-section`.

--- a/remote_access.rst
+++ b/remote_access.rst
@@ -286,10 +286,6 @@ USB-to-Serial Adapters
 In case of need, NethSecurity can be used to access another server via the serial console. If the hardware does not have an RS-232 port, USB-to-serial adapters can be used. 
 For this reason, it is possible to download and install drivers for the most common adapters on NethSecurity. These drivers are provided as-is and are **not supported by Nethesis** (if using an Enterprise or Subscription version).
 
-.. warning::
-
- Extra packages, including kernel modules, are not preserved across image upgrades, so in the event of an upgrade, you will need to download and install them again if needed.
-
 Two packages are provided for installation, covering the vast majority of adapters available on the market.
 ::
 
@@ -309,3 +305,8 @@ Two packages are provided for installation, covering the vast majority of adapte
     Aug  6 08:08:17 nsec8 kernel: [ 2346.359247] usb 1-6: new full-speed USB device number 3 using xhci_hcd
     Aug  6 08:08:17 nsec8 kernel: [ 2346.543052] pl2303 1-6:1.0: pl2303 converter detected
     Aug  6 08:08:17 nsec8 kernel: [ 2346.550401] usb 1-6: pl2303 converter now attached to ttyUSB0
+
+.. note::
+   Starting from version 8.7.2 of NethSecurity, extra packages are preserved during system upgrades.
+   For earlier versions, please refer to the following documentation to restore extra packages after an upgrade :ref:`restore_extra_packages-section`.
+

--- a/updates.rst
+++ b/updates.rst
@@ -47,15 +47,14 @@ The ``sysupgrade`` command flashes the new image file to the device.
 
 Restore extra packages
 ----------------------
-.. note::
-   Starting from version 8.7.2 of NethSecurity, extra packages are preserved during system upgrades.
-   Refer to the following documentation for earlier versions or for troubleshooting scenarios.
+Starting from version 8.7.2 of NethSecurity, extra packages are preserved during system upgrades.
+See the next section for earlier versions.
 
-After the upgrade has been done, to list all extra packages, run the following command: ::
+After the upgrade, you can run the following command to list all extra packages: ::
 
   grep overlay /etc/backup/installed_packages.txt
 
-This command returns all extra packages, making it easier to verify which ones are installed and whether they are running correctly.
+This command returns all extra packages, allowing you to verify which ones are installed and present on the system.
 
 Restore extra packages on versions before 8.7.2
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/updates.rst
+++ b/updates.rst
@@ -47,7 +47,9 @@ The ``sysupgrade`` command flashes the new image file to the device.
 
 Restore extra packages
 ----------------------
-Starting from version 8.7.2 of NethSecurity, extra packages are preserved during system upgrades.
+Starting from version 8.7.2, extra packages are automatically reinstalled after system upgrade.
+Please note that the reinstall procedure requires access to Internet.
+In case of error, proceed with the manual restore documented below.
 See the next section for earlier versions.
 
 After the upgrade, you can run the following command to list all extra packages: ::

--- a/updates.rst
+++ b/updates.rst
@@ -43,19 +43,27 @@ Then run the following command: ::
 
 The ``sysupgrade`` command flashes the new image file to the device.
 
-.. note::
-   Starting from version 8.7.2 of NethSecurity, extra packages are preserved during system upgrades.
-   For earlier versions, please refer to the following documentation to restore extra packages after an upgrade :ref:`restore_extra_packages-section`.
-
 .. _restore_extra_packages-section:
 
 Restore extra packages
 ----------------------
+.. note::
+   Starting from version 8.7.2 of NethSecurity, extra packages are preserved during system upgrades.
+   Refer to the following documentation for earlier versions or for troubleshooting scenarios.
 
-During the upgrade, the system will be completely rewritten, so all the extra packages installed by the user will be lost. This applies to versions earlier than 8.7.2.
-Still, the list of installed packages is saved in the configuration backup, so it is possible to restore them after the upgrade.
+After the upgrade has been done, to list all extra packages, run the following command: ::
 
-After the upgrade, make sure the system can access the internet, then restore previously installed packages using the following commands: ::
+  grep overlay /etc/backup/installed_packages.txt
+
+This command returns all extra packages, making it easier to verify which ones are installed and whether they are running correctly.
+
+Restore extra packages on versions before 8.7.2
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+During the upgrade, the system is completely rewritten, and all extra packages installed by the user will be lost.
+However, the list of installed packages is saved in the configuration backup, allowing them to be restored after the upgrade.
+
+After the upgrade, ensure that the system has internet access, then restore the previously installed packages using the following commands: ::
 
   opkg update
   grep -E '\w+\s+overlay$' /etc/backup/installed_packages.txt | awk '{print $1}' | xargs opkg install

--- a/updates.rst
+++ b/updates.rst
@@ -26,10 +26,6 @@ System upgrades
 
 This types of upgrages involve the transition to a new version of the firmware that introduces new features, improvements and wider hardware support.
 
-.. note::
-
-  The upgrade will preserve all the configurations and settings, but it will not preserve extra packages installed by the user.
-
 This type of update will reboot the device (which will therefore not be reachable for a few dozen seconds) and then completely rewrites the firmware, preserving all the configurations.
 However it is recommended to save a configuration backup before proceeding with the upgrade.
 
@@ -47,12 +43,16 @@ Then run the following command: ::
 
 The ``sysupgrade`` command flashes the new image file to the device.
 
+.. note::
+   Starting from version 8.7.2 of NethSecurity, extra packages are preserved during system upgrades.
+   For earlier versions, please refer to the following documentation to restore extra packages after an upgrade :ref:`restore_extra_packages-section`.
+
 .. _restore_extra_packages-section:
 
 Restore extra packages
 ----------------------
 
-During the upgrade, the system will be completely rewritten, so all the extra packages installed by the user will be lost.
+During the upgrade, the system will be completely rewritten, so all the extra packages installed by the user will be lost. This applies to versions earlier than 8.7.2.
 Still, the list of installed packages is saved in the configuration backup, so it is possible to restore them after the upgrade.
 
 After the upgrade, make sure the system can access the internet, then restore previously installed packages using the following commands: ::

--- a/updates.rst
+++ b/updates.rst
@@ -58,8 +58,11 @@ After the upgrade, you can run the following command to list all extra packages:
 
 This command returns all extra packages, allowing you to verify which ones are installed and present on the system.
 
-Restore extra packages on versions before 8.7.2
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Manually restore extra packages
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This manual procedure is required only on versions before 8.7.2 or if the automatic reinstall procedure fails.
+
 
 During the upgrade, the system is completely rewritten, and all extra packages installed by the user will be lost.
 However, the list of installed packages is saved in the configuration backup, allowing them to be restored after the upgrade.

--- a/ups.rst
+++ b/ups.rst
@@ -43,7 +43,9 @@ Install the required packages::
     opkg update
     opkg install nut-server nut-upsc nut-upsmon nut-upscmd
 
-These packages are not preserved during a system upgrade. For more info see :ref:`restore_extra_packages-section`.
+.. note::
+   Starting from version 8.7.2 of NethSecurity, extra packages are preserved during system upgrades.
+   For earlier versions, please refer to the following documentation to restore extra packages after an upgrade :ref:`restore_extra_packages-section`.
 
 Step 2: setup the appropriate driver
 ------------------------------------

--- a/wol.rst
+++ b/wol.rst
@@ -18,7 +18,9 @@ Install the package with::
     opkg update
     opkg install etherwake
 
-These packages are not preserved during a system upgrade. For more info see :ref:`restore_extra_packages-section`.
+.. note::
+   Starting from version 8.7.2 of NethSecurity, extra packages are preserved during system upgrades.
+   For earlier versions, please refer to the following documentation to restore extra packages after an upgrade :ref:`restore_extra_packages-section`.
 
 Usage
 -----

--- a/wol.rst
+++ b/wol.rst
@@ -19,7 +19,7 @@ Install the package with::
     opkg install etherwake
 
 .. note::
-   Starting from version 8.7.2 of NethSecurity, extra packages are preserved during system upgrades.
+   Starting from version 8.7.2, extra packages are automatically reinstalled after system upgrade.
    For earlier versions and for additional information, refer to this documentation: :ref:`restore_extra_packages-section`.
 
 Usage

--- a/wol.rst
+++ b/wol.rst
@@ -20,7 +20,7 @@ Install the package with::
 
 .. note::
    Starting from version 8.7.2 of NethSecurity, extra packages are preserved during system upgrades.
-   For earlier versions, please refer to the following documentation to restore extra packages after an upgrade :ref:`restore_extra_packages-section`.
+   For earlier versions and for additional information, refer to this documentation: :ref:`restore_extra_packages-section`.
 
 Usage
 -----


### PR DESCRIPTION
Clarify that starting fron NethSecurity 8.7.2 extra packages are preserved during the upgrade.

