### PR TITLE
fix: forward port 9090

### DIFF
--- a/controller.rst
+++ b/controller.rst
@@ -151,6 +151,8 @@ When the unit is connected, the user can access the unit web interface by clicki
 .. note:: 
 
   The unit user interface :ref:`must listen on port 9090 <change_ui_port-section>` to allow the controller to access it.
+  The controller will access the unit web interface through the VPN connection. The port 9090 does not need to be open from
+  the WAN side, but it must be open from the VPN side to allow the controller to access it.
 
 .. rubric:: Remove a unit
 

--- a/remote_access.rst
+++ b/remote_access.rst
@@ -96,6 +96,10 @@ To change the NethSecurity UI port from 9090 to 8181, execute: ::
 
   The controller uses port 9090 to communicate with the unit. Changing the port will prevent the controller from managing the NethSecurity.
 
+If you still need to forward port 9090 to another machine inside the LAN, you can keep the controller connected by leaving the ``ns-ui_extra_port``
+unchanged and forwarding the port to the new machine.
+Forwarding the port to another machine will be acceptable because the controller will reach port 9090 over the VPN.
+
 Disable web user interface on port 443
 --------------------------------------
 


### PR DESCRIPTION
Keep the port 9090 from the inside to allow the
controller to connect, even if port 9090 must be forwarded.