### PR TITLE
Https dns proxy fix configuration

### DIFF
--- a/dns_over_http.rst
+++ b/dns_over_http.rst
@@ -56,7 +56,7 @@ In this example, we will configure the JoinDNS4 DoH provider.
 2. Add the JoinDNS4 DoH provider: ::
 
      uci set https-dns-proxy.joindns4=https-dns-proxy
-     uci set https-dns-proxy.joindns4.upstream_url='https://noads.joindns4.eu/dns-query'
+     uci set https-dns-proxy.joindns4.resolver_url='https://noads.joindns4.eu/dns-query'
      uci set https-dns-proxy.joindns4.listen_addr='127.0.0.1'
      uci set https-dns-proxy.joindns4.listen_port='5053'
      uci commit https-dns-proxy  

--- a/dns_over_http.rst
+++ b/dns_over_http.rst
@@ -57,9 +57,13 @@ In this example, we will configure the JoinDNS4 DoH provider.
 
      uci set https-dns-proxy.joindns4=https-dns-proxy
      uci set https-dns-proxy.joindns4.resolver_url='https://noads.joindns4.eu/dns-query'
+     uci set https-dns-proxy.joindns4.bootstrap_dns='86.54.11.13,86.54.11.213,2a13:1001::86:54:11:13,2a13:1001::86:54:11:213'
      uci set https-dns-proxy.joindns4.listen_addr='127.0.0.1'
      uci set https-dns-proxy.joindns4.listen_port='5053'
      uci commit https-dns-proxy  
+
+
+The ``bootstrap_dns`` parameter is optional, if not provided, the system will use Google and Cloudflare DNS for bootstrap.
 
 3. Apply the configuration, https-dns-proxy will automatically use the local DoH proxy as upstream DNS: ::
 


### PR DESCRIPTION
The `upstream_url` parameter doesn't work well, I tested with different DNSs and the query were always redirected to bootstrap DNS (Google).

Using `resolver_url` I had the desired behaviour.
 I also added a note about bootstrap DNS in case you want to choose a specific one.
