### PR TITLE
docs: connection history storage options for OpenVPN Road Warrior

### DIFF
--- a/openvpn_roadwarrior.rst
+++ b/openvpn_roadwarrior.rst
@@ -251,7 +251,7 @@ The MTU values may need to be adjusted to fit your specific network environment.
 Connection history
 ------------------
 
-Every time a client connects or disconnects from the server, the event is saved inside a SQLite database stored in RAM.
+Every time a client connects or disconnects from the server, the event is saved inside a SQLite database.
 Such event history can be viewed by clicking on tab ``Connection History`` available on the top of the page.
 
 By default the page will display all connections from current day, but it is possible to filter the results by date and time and account name.
@@ -259,5 +259,14 @@ By default the page will display all connections from current day, but it is pos
 To download all history in CSV format, click on the button :guilabel:`Download server history`.
 The header of the CSV file explains the meaning of each column, including the units of measure.
 
-Once the server is rebooted, the local history is lost.
+History is read from an SQLite database that can be stored in:
+
+- **RAM**: stored in RAM (not persistent); it will be lost when the firewall reboots.
+- **Storage**: stored on persistent storage; it will survive a reboot.
+
+By default, if persistent storage is available and configured, connection events are stored in the storage database, otherwise they are stored in the RAM database.
+
+If a RoadWarrior server is already configured and a new storage device is connected, the history is automatically moved from RAM to storage, making it persistent and able to survive reboots. 
+Conversely, if the storage is removed, new connection events will be stored in the RAM database and will be visible in the Connections History section. If the storage is then reconnected, the histories from RAM and storage are merged without data loss.
+
 If the server is connected to a :ref:`controller-section`, the history is sent to the controller and can be viewed inside the :ref:`historical_monitoring-section`.


### PR DESCRIPTION
This pull request updates the documentation for connection history management in the OpenVPN RoadWarrior server. The changes clarify how connection event history is stored, its persistence across reboots, and how history is handled when storage devices are added or removed.

**Documentation improvements regarding connection history storage and persistence:**

* Clarified that connection event history is saved in an SQLite database, which can be stored either in RAM (volatile, lost on reboot) or on persistent storage (survives reboots).
* Explained the default behavior: if persistent storage is configured, events are stored there; otherwise, RAM is used.
* Documented the automatic migration of history from RAM to storage when a new storage device is connected, and the merging of histories if storage is reconnected after removal.