### PR TITLE
Document bundled https-dns-proxy defaults

### DIFF
--- a/dns_over_http.rst
+++ b/dns_over_http.rst
@@ -37,6 +37,11 @@ On NethSecurity 7.7, the package is not included in default NethSecurity image, 
   opkg update
   opkg install https-dns-proxy
 
+On NethSecurity 7.7, the package is not included in default NethSecurity image, so you will need to install it manually: ::
+
+  opkg update
+  opkg install https-dns-proxy
+
 Configuration
 =============
 

--- a/dns_over_http.rst
+++ b/dns_over_http.rst
@@ -118,8 +118,6 @@ However, NethSecurity treats ``dnsmasq_config_update='-'`` as the disabled
 state. If that value is still set during an image upgrade, the first-boot
 defaults script can disable ``https-dns-proxy`` again.
 
-At the moment this is not expected to be a practical problem because
-configuration is supported only from the command line.
 
 Blocking other DoH providers
 ----------------------------

--- a/dns_over_http.rst
+++ b/dns_over_http.rst
@@ -29,7 +29,7 @@ Some popular alternatives include:
 Installation
 ============
 
-The ``https-dns-proxy`` package is included in NethSecurity images, so no
+Since NethSecurity 8.8, the ``https-dns-proxy`` package is included in NethSecurity image, so no
 separate installation step is required.
 
 Configuration

--- a/dns_over_http.rst
+++ b/dns_over_http.rst
@@ -37,11 +37,6 @@ On NethSecurity 7.7, the package is not included in default NethSecurity image, 
   opkg update
   opkg install https-dns-proxy
 
-On NethSecurity 7.7, the package is not included in default NethSecurity image, so you will need to install it manually: ::
-
-  opkg update
-  opkg install https-dns-proxy
-
 Configuration
 =============
 

--- a/dns_over_http.rst
+++ b/dns_over_http.rst
@@ -32,6 +32,11 @@ Installation
 Since NethSecurity 8.8, the ``https-dns-proxy`` package is included in NethSecurity image, so no
 separate installation step is required.
 
+On NethSecurity 7.7, the package is not included in default NethSecurity image, so you will need to install it manually: ::
+
+  opkg update
+  opkg install https-dns-proxy
+
 Configuration
 =============
 

--- a/dns_over_http.rst
+++ b/dns_over_http.rst
@@ -32,7 +32,7 @@ Installation
 Since NethSecurity 8.8, the ``https-dns-proxy`` package is included in NethSecurity image, so no
 separate installation step is required.
 
-On NethSecurity 7.7, the package is not included in default NethSecurity image, so you will need to install it manually: ::
+On NethSecurity 8.7, the package is not included in default NethSecurity image, so you will need to install it manually: ::
 
   opkg update
   opkg install https-dns-proxy

--- a/dns_over_http.rst
+++ b/dns_over_http.rst
@@ -10,8 +10,9 @@ DNS over HTTPS (DoH) is a protocol for encrypting DNS queries over HTTPS, enhanc
 This feature allows you to configure upstream DNS servers that support the DoH protocol.
 The ``https-dns-proxy`` package provides a local DNS-to-HTTPS proxy that forwards DNS queries to a remote DoH provider.
 
-This document provides instructions for installing and configuring the DoH upstream servers that provide
-filtering and are based in the EU, but you can use any DoH provider that suits your needs.
+This document provides instructions for configuring DoH upstream servers that
+provide filtering and are based in the EU, but you can use any DoH provider
+that suits your needs.
 This configuration only applies to the upstream servers of the firewall: clients will continue to send DNS requests to the firewall in plaintext on port 53.
 
 A list of DoH providers that support European locations and filtering are available on the
@@ -28,20 +29,23 @@ Some popular alternatives include:
 Installation
 ============
 
-The ``https-dns-proxy`` package is not included in default NethSecurity images, so you will need to install it manually: ::
-
-  opkg update
-  opkg install https-dns-proxy
+The ``https-dns-proxy`` package is included in NethSecurity images, so no
+separate installation step is required.
 
 Configuration
 =============
 
-By default, the package includes two providers (Cloudflare and Google).
-To use a custom DoH provider, you'll need to:
+By default, the package includes two providers (Cloudflare and Google), listens
+on ``127.0.0.1:5053`` and ``127.0.0.1:5054``, and keeps
+``dnsmasq_config_update`` set to ``-`` so it does not modify the firewall DNS
+configuration automatically.
+
+To start using the proxy, you need to:
 
 1. Remove the default providers (optional)
 2. Add your preferred DoH provider configuration
-3. Commit and apply the configuration
+3. Choose the ``dnsmasq_config_update`` value to use
+4. Commit the configuration and enable the service
 
 Configuration steps
 -------------------
@@ -65,9 +69,16 @@ In this example, we will configure the DNS4EU (joindns4.eu) DoH provider.
 
 The ``bootstrap_dns`` parameter is optional, if not provided, the system will use Google and Cloudflare DNS for bootstrap.
 
-3. Apply the configuration, https-dns-proxy will automatically use the local DoH proxy as upstream DNS: ::
+3. Enable integration with ``dnsmasq`` and start the service: ::
 
-     reload_config
+     uci set https-dns-proxy.config.dnsmasq_config_update='*'
+     uci commit https-dns-proxy
+     /etc/init.d/https-dns-proxy enable
+     /etc/init.d/https-dns-proxy start
+
+   The value ``*`` updates all ``dnsmasq`` instances. If you need a more
+   specific integration, set ``dnsmasq_config_update`` to the instance name or
+   index you want to manage.
 
 Verification
 ^^^^^^^^^^^^
@@ -100,18 +111,15 @@ Run the following commands via SSH or terminal: ::
 Image update
 ------------
 
-The ``https-dns-proxy`` package overrides the default DNS configuration,
-so if you update your NethSecurity image, the system will not be able to connect to Internet
-and restore the package.
+The package is included in the image, so it does not need to be reinstalled
+after an upgrade.
 
-To overcome this issue, you can temporarily stop the DoH proxy before updating the image: ::
+However, NethSecurity treats ``dnsmasq_config_update='-'`` as the disabled
+state. If that value is still set during an image upgrade, the first-boot
+defaults script can disable ``https-dns-proxy`` again.
 
-  service https-dns-proxy stop
-
-This will restore the default DNS configuration and allow the system to connect to the Internet
-after image update. Once the update is complete, you can restart the DoH proxy: ::
-
-  service https-dns-proxy restart
+At the moment this is not expected to be a practical problem because
+configuration is supported only from the command line.
 
 Blocking other DoH providers
 ----------------------------


### PR DESCRIPTION
## Summary

- update the DoH guide for bundled `https-dns-proxy`
- document that the service starts disabled and must be explicitly enabled
- document the `dnsmasq_config_update='-'` upgrade caveat

## Related issue

None. Draft PR opened without a linked issue.

## How to test

1. Read `dns_over_http.rst`.
2. Verify it no longer instructs manual package installation.
3. Verify it documents `dnsmasq_config_update='*'` plus `/etc/init.d/https-dns-proxy enable` as the activation flow.
4. Verify it explains the image-upgrade caveat when `dnsmasq_config_update` remains `-`.

## Dependencies

- https://github.com/NethServer/nethsecurity/pull/1691
