### PR TITLE
docs: clarify extra package restore retries

### DIFF
--- a/updates.rst
+++ b/updates.rst
@@ -49,6 +49,9 @@ Restore extra packages
 ----------------------
 Starting from version 8.7.2, extra packages are automatically reinstalled after system upgrade.
 Please note that the reinstall procedure requires access to Internet.
+If one or more packages cannot be installed because the network is not yet ready or a transient error occurs,
+the restore service stays enabled and retries automatically on the next boot until all packages are restored.
+Only packages that are actually installed successfully are reported as restored.
 In case of error, proceed with the manual restore documented below.
 See the next section for earlier versions.
 

--- a/updates.rst
+++ b/updates.rst
@@ -52,6 +52,12 @@ Please note that the reinstall procedure requires access to Internet.
 If one or more packages cannot be installed because the network is not yet ready or a transient error occurs,
 the restore service stays enabled and retries automatically on the next boot until all packages are restored.
 Only packages that are actually installed successfully are reported as restored.
+For example, a mixed restore may log::
+
+  Restored package: etherwake
+  Failed to restore package: qemu-ga
+  Some packages failed to restore, will retry later
+
 In case of error, proceed with the manual restore documented below.
 See the next section for earlier versions.
 

--- a/updates.rst
+++ b/updates.rst
@@ -51,7 +51,7 @@ Starting from version 8.7.2, extra packages are automatically reinstalled after 
 Please note that the reinstall procedure requires access to Internet.
 If one or more packages cannot be installed because the network is not yet ready or a transient error occurs,
 the restore service stays enabled and retries automatically on the next boot until all packages are restored.
-Only packages that are actually installed successfully are reported as restored.
+Restored packages are reported inside the log.
 For example, a mixed restore may log::
 
   Restored package: etherwake


### PR DESCRIPTION
Update the "Restore extra packages" section to describe the retry behavior introduced in NethServer/nethsecurity#1671:

- automatic retries on later boots when package installs fail
- restore service remains enabled until all packages are restored
- only successful installs are reported as restored
