### PR TITLE
docs: note persistent DHCP leases on storage

### DIFF
--- a/dns_dhcp.rst
+++ b/dns_dhcp.rst
@@ -96,6 +96,11 @@ Dynamic leases
 Dynamic leases represents IP addresses that are currently in use and have been allocated to devices on the network.
 This tab shows all currently active leases.
 
+.. note::
+   When :ref:`storage-section` is configured, dnsmasq stores the lease file in
+   ``/mnt/data/dnsmasq/dhcp.leases``, so dynamic leases survive reboots.
+   Otherwise it keeps using ``/tmp/dhcp.leases``.
+
 Default Configuration
 ---------------------
 


### PR DESCRIPTION
Document that dynamic leases survive reboots when NethSecurity storage is configured.

- dnsmasq stores the lease file under `/mnt/data/dnsmasq/dhcp.leases` when storage is available
- `/tmp/dhcp.leases` remains the fallback path when storage is not configured

Refs: NethServer/nethsecurity#1694, NethServer/nethsecurity#1695
