### PR TITLE
docs: document opkg and apk command equivalents

### DIFF
--- a/checkmk.rst
+++ b/checkmk.rst
@@ -20,7 +20,14 @@ If you only need the upstream agent, install ``checkmk-agent`` alone.
 Install the packages
 --------------------
 
-Install the agent and the optional NethSecurity checks from the command line::
+Install the agent and the optional NethSecurity checks from the command line.
+
+If you are using NethSecurity 8.8, use::
+
+    apk update
+    apk add ns-checkmk-utils
+
+If you are using NethSecurity 8.7, use::
 
     opkg update
     opkg install ns-checkmk-utils

--- a/checkmk.rst
+++ b/checkmk.rst
@@ -22,12 +22,12 @@ Install the packages
 
 Install the agent and the optional NethSecurity checks from the command line.
 
-If you are using NethSecurity 8.8, use::
+If you are running NethSecurity 8.8, use::
 
     apk update
     apk add ns-checkmk-utils
 
-If you are using NethSecurity 8.7, use::
+If you are running NethSecurity 8.7, use::
 
     opkg update
     opkg install ns-checkmk-utils

--- a/checkmk.rst
+++ b/checkmk.rst
@@ -27,7 +27,7 @@ If you are running NethSecurity 8.8, use::
     apk update
     apk add ns-checkmk-utils
 
-If you are running NethSecurity 8.7, use::
+If you are running NethSecurity 8.7 or older, use::
 
     opkg update
     opkg install ns-checkmk-utils

--- a/checkmk.rst
+++ b/checkmk.rst
@@ -27,7 +27,7 @@ If you are running NethSecurity 8.8, use::
     apk update
     apk add ns-checkmk-utils
 
-If you are running NethSecurity 8.7 or older, use::
+If you are running NethSecurity 8.7.2 or older, use::
 
     opkg update
     opkg install ns-checkmk-utils

--- a/install.rst
+++ b/install.rst
@@ -136,12 +136,12 @@ The agent can work when the virtual machine is running on KVM, Proxmox, or other
 
 First, make sure the virtual machine is running, then connect to the machine using SSH or the Proxmox console.
 
-If you are using NethSecurity 8.8, use::
+If you are running NethSecurity 8.8, use::
 
     apk update
     apk add qemu-ga
 
-If you are using NethSecurity 8.7, use::
+If you are running NethSecurity 8.7, use::
 
     opkg update
     opkg install qemu-ga
@@ -188,12 +188,12 @@ The tools can work only when the virtual machine is running on VMWare hypervisor
 
 First, make sure the virtual machine is running, then connect to the machine using SSH or the VMWare console.
 
-If you are using NethSecurity 8.8, use::
+If you are running NethSecurity 8.8, use::
 
     apk update
     apk add open-vm-tools
 
-If you are using NethSecurity 8.7, use::
+If you are running NethSecurity 8.7, use::
 
     opkg update
     opkg install open-vm-tools

--- a/install.rst
+++ b/install.rst
@@ -141,7 +141,7 @@ If you are running NethSecurity 8.8, use::
     apk update
     apk add qemu-ga
 
-If you are running NethSecurity 8.7 or older, use::
+If you are running NethSecurity 8.7.2 or older, use::
 
     opkg update
     opkg install qemu-ga
@@ -193,7 +193,7 @@ If you are running NethSecurity 8.8, use::
     apk update
     apk add open-vm-tools
 
-If you are running NethSecurity 8.7 or older, use::
+If you are running NethSecurity 8.7.2 or older, use::
 
     opkg update
     opkg install open-vm-tools

--- a/install.rst
+++ b/install.rst
@@ -134,11 +134,17 @@ QEMU guest agent
 QEMU guest agent is not part of the NethSecurity image but can be installed from the command line.
 The agent can work when the virtual machine is running on KVM, Proxmox, or other QEMU-based hypervisors.
 
-First, make sure the virtual machine is running, then connect to the machine using SSH or the Proxmox console and
-execute the following commands: ::
+First, make sure the virtual machine is running, then connect to the machine using SSH or the Proxmox console.
 
-  opkg update
-  opkg install qemu-ga
+If you are using NethSecurity 8.8, use::
+
+    apk update
+    apk add qemu-ga
+
+If you are using NethSecurity 8.7, use::
+
+    opkg update
+    opkg install qemu-ga
 
 After the installation, start the service: ::
 
@@ -180,11 +186,17 @@ VMware open-vm-tools
 VMware open-vm-tools are not part of the NethSecurity image but can be installed from the command line.
 The tools can work only when the virtual machine is running on VMWare hypervisors.
 
-First make sure the virtual machine is running, then connect to the machine using SSH or the VMWare console and
-execute the following commands: ::
+First, make sure the virtual machine is running, then connect to the machine using SSH or the VMWare console.
 
-  opkg update
-  opkg install open-vm-tools
+If you are using NethSecurity 8.8, use::
+
+    apk update
+    apk add open-vm-tools
+
+If you are using NethSecurity 8.7, use::
+
+    opkg update
+    opkg install open-vm-tools
 
 After the installation, start the service: ::
 

--- a/install.rst
+++ b/install.rst
@@ -141,7 +141,7 @@ If you are running NethSecurity 8.8, use::
     apk update
     apk add qemu-ga
 
-If you are running NethSecurity 8.7, use::
+If you are running NethSecurity 8.7 or older, use::
 
     opkg update
     opkg install qemu-ga
@@ -193,7 +193,7 @@ If you are running NethSecurity 8.8, use::
     apk update
     apk add open-vm-tools
 
-If you are running NethSecurity 8.7, use::
+If you are running NethSecurity 8.7 or older, use::
 
     opkg update
     opkg install open-vm-tools

--- a/logs.rst
+++ b/logs.rst
@@ -71,7 +71,7 @@ If you are running NethSecurity 8.8, use::
     apk update
     apk add ns-clm
 
-If you are running NethSecurity 8.7, use::
+If you are running NethSecurity 8.7 or older, use::
 
     opkg update
     opkg install ns-clm

--- a/logs.rst
+++ b/logs.rst
@@ -66,12 +66,12 @@ The daemon polls for new lines every 10 seconds, detects log rotation automatica
 The package is not included by default on NethSecurity 8.7.2 or earlier, but it is available in the package repository and can be
 manually installed.
 
-If you are using NethSecurity 8.8, use::
+If you are running NethSecurity 8.8, use::
 
     apk update
     apk add ns-clm
 
-If you are using NethSecurity 8.7, use::
+If you are running NethSecurity 8.7, use::
 
     opkg update
     opkg install ns-clm

--- a/logs.rst
+++ b/logs.rst
@@ -65,10 +65,16 @@ The daemon polls for new lines every 10 seconds, detects log rotation automatica
 
 The package is not included by default on NethSecurity 8.7.2 or earlier, but it is available in the package repository and can be
 manually installed.
-Install it with: ::
 
-  opkg update
-  opkg install ns-clm
+If you are using NethSecurity 8.8, use::
+
+    apk update
+    apk add ns-clm
+
+If you are using NethSecurity 8.7, use::
+
+    opkg update
+    opkg install ns-clm
 
 The UCI configuration is stored in ``/etc/config/ns-clm``:
 

--- a/logs.rst
+++ b/logs.rst
@@ -71,7 +71,7 @@ If you are running NethSecurity 8.8, use::
     apk update
     apk add ns-clm
 
-If you are running NethSecurity 8.7 or older, use::
+If you are running NethSecurity 8.7.2 or older, use::
 
     opkg update
     opkg install ns-clm

--- a/network.rst
+++ b/network.rst
@@ -169,7 +169,7 @@ These packages can be installed from the command line console, just find the cor
       apk update
       apk search kmod-usb-net-*
 
-  If you are running NethSecurity 8.7, use::
+  If you are running NethSecurity 8.7 or older, use::
 
       opkg update
       opkg find kmod-usb-net-*
@@ -197,7 +197,7 @@ These packages can be installed from the command line console, just find the cor
 
       apk add kmod-usb-net-rtl8150
 
-  If you are running NethSecurity 8.7, use::
+  If you are running NethSecurity 8.7 or older, use::
 
       opkg install kmod-usb-net-rtl8150
 

--- a/network.rst
+++ b/network.rst
@@ -162,12 +162,17 @@ These packages can be installed from the command line console, just find the cor
     Bus 001 Device 002: ID 0627:0001 QEMU QEMU USB Tablet
     Bus 001 Device 001: ID 1d6b:0002 Linux 5.15.162 xhci-hcd xHCI Host Controller
 
-* Search for the the kernel module: 
+* Search for the kernel module:
 
-  ::
+  If you are using NethSecurity 8.8, use::
 
-    opkg update
-    opkg find kmod-usb-net-\*
+      apk update
+      apk search kmod-usb-net-*
+
+  If you are using NethSecurity 8.7, use::
+
+      opkg update
+      opkg find kmod-usb-net-*
 
 * Output example:
 
@@ -188,9 +193,13 @@ These packages can be installed from the command line console, just find the cor
 
 * Install the right driver:
 
-  ::
+  If you are using NethSecurity 8.8, use::
 
-    opkg install kmod-usb-net-rtl8150
+      apk add kmod-usb-net-rtl8150
+
+  If you are using NethSecurity 8.7, use::
+
+      opkg install kmod-usb-net-rtl8150
 
 * Verify a new ethX interface appears using ``ifconfig -a``
 * Configure the ethernet from the UI

--- a/network.rst
+++ b/network.rst
@@ -164,12 +164,12 @@ These packages can be installed from the command line console, just find the cor
 
 * Search for the kernel module:
 
-  If you are using NethSecurity 8.8, use::
+  If you are running NethSecurity 8.8, use::
 
       apk update
       apk search kmod-usb-net-*
 
-  If you are using NethSecurity 8.7, use::
+  If you are running NethSecurity 8.7, use::
 
       opkg update
       opkg find kmod-usb-net-*
@@ -193,11 +193,11 @@ These packages can be installed from the command line console, just find the cor
 
 * Install the right driver:
 
-  If you are using NethSecurity 8.8, use::
+  If you are running NethSecurity 8.8, use::
 
       apk add kmod-usb-net-rtl8150
 
-  If you are using NethSecurity 8.7, use::
+  If you are running NethSecurity 8.7, use::
 
       opkg install kmod-usb-net-rtl8150
 

--- a/network.rst
+++ b/network.rst
@@ -169,7 +169,7 @@ These packages can be installed from the command line console, just find the cor
       apk update
       apk search kmod-usb-net-*
 
-  If you are running NethSecurity 8.7 or older, use::
+  If you are running NethSecurity 8.7.2 or older, use::
 
       opkg update
       opkg find kmod-usb-net-*
@@ -197,7 +197,7 @@ These packages can be installed from the command line console, just find the cor
 
       apk add kmod-usb-net-rtl8150
 
-  If you are running NethSecurity 8.7 or older, use::
+  If you are running NethSecurity 8.7.2 or older, use::
 
       opkg install kmod-usb-net-rtl8150
 

--- a/remote_access.rst
+++ b/remote_access.rst
@@ -337,9 +337,15 @@ Two packages are provided for installation, covering the vast majority of adapte
 
 * To install Prolific PL2303 driver:
 
-  ::
+  If you are using NethSecurity 8.8, use::
 
-    opkg install kmod-usb-serial-pl2303
+      apk update
+      apk add kmod-usb-serial-pl2303
+
+  If you are using NethSecurity 8.7, use::
+
+      opkg update
+      opkg install kmod-usb-serial-pl2303
 
 * The logs will show an output similar to this:
 

--- a/remote_access.rst
+++ b/remote_access.rst
@@ -337,12 +337,12 @@ Two packages are provided for installation, covering the vast majority of adapte
 
 * To install Prolific PL2303 driver:
 
-  If you are using NethSecurity 8.8, use::
+  If you are running NethSecurity 8.8, use::
 
       apk update
       apk add kmod-usb-serial-pl2303
 
-  If you are using NethSecurity 8.7, use::
+  If you are running NethSecurity 8.7, use::
 
       opkg update
       opkg install kmod-usb-serial-pl2303

--- a/remote_access.rst
+++ b/remote_access.rst
@@ -342,7 +342,7 @@ Two packages are provided for installation, covering the vast majority of adapte
       apk update
       apk add kmod-usb-serial-pl2303
 
-  If you are running NethSecurity 8.7, use::
+  If you are running NethSecurity 8.7 or older, use::
 
       opkg update
       opkg install kmod-usb-serial-pl2303

--- a/remote_access.rst
+++ b/remote_access.rst
@@ -342,7 +342,7 @@ Two packages are provided for installation, covering the vast majority of adapte
       apk update
       apk add kmod-usb-serial-pl2303
 
-  If you are running NethSecurity 8.7 or older, use::
+  If you are running NethSecurity 8.7.2 or older, use::
 
       opkg update
       opkg install kmod-usb-serial-pl2303

--- a/updates.rst
+++ b/updates.rst
@@ -69,12 +69,12 @@ However, the list of installed packages is saved in the configuration backup, al
 
 After the upgrade, ensure that the system has Internet access, then restore the previously installed packages using the commands that match your NethSecurity version.
 
-If you are using NethSecurity 8.8, use::
+If you are running NethSecurity 8.8, use::
 
   apk update
   grep -E '\w+\s+overlay$' /etc/backup/installed_packages.txt | awk '{print $1}' | xargs apk add
 
-If you are using NethSecurity 8.7, use::
+If you are running NethSecurity 8.7, use::
 
   opkg update
   grep -E '\w+\s+overlay$' /etc/backup/installed_packages.txt | awk '{print $1}' | xargs opkg install

--- a/updates.rst
+++ b/updates.rst
@@ -85,7 +85,7 @@ Updates are checked daily and, if available, they are automatically downloaded a
 Package manager commands
 ========================
 
-NethSecurity 8.8 uses ``apk``. NethSecurity 8.7 and earlier use ``opkg``.
+NethSecurity 8.8 uses ``apk``. NethSecurity 8.7.2 and earlier use ``opkg``.
 Use the following quick reference when translating older command examples:
 
 .. list-table::

--- a/updates.rst
+++ b/updates.rst
@@ -67,14 +67,7 @@ This manual procedure is required only on versions before 8.7.2 or if the automa
 During the upgrade, the system is completely rewritten, and all extra packages installed by the user will be lost.
 However, the list of installed packages is saved in the configuration backup, allowing them to be restored after the upgrade.
 
-After the upgrade, ensure that the system has Internet access, then restore the previously installed packages using the commands that match your NethSecurity version.
-
-If you are running NethSecurity 8.8, use::
-
-  apk update
-  grep -E '\w+\s+overlay$' /etc/backup/installed_packages.txt | awk '{print $1}' | xargs apk add
-
-If you are running NethSecurity 8.7 or older, use::
+After the upgrade, ensure that the system has internet access, then restore the previously installed packages using the following commands: ::
 
   opkg update
   grep -E '\w+\s+overlay$' /etc/backup/installed_packages.txt | awk '{print $1}' | xargs opkg install

--- a/updates.rst
+++ b/updates.rst
@@ -67,7 +67,14 @@ This manual procedure is required only on versions before 8.7.2 or if the automa
 During the upgrade, the system is completely rewritten, and all extra packages installed by the user will be lost.
 However, the list of installed packages is saved in the configuration backup, allowing them to be restored after the upgrade.
 
-After the upgrade, ensure that the system has internet access, then restore the previously installed packages using the following commands: ::
+After the upgrade, ensure that the system has Internet access, then restore the previously installed packages using the commands that match your NethSecurity version.
+
+If you are using NethSecurity 8.8, use::
+
+  apk update
+  grep -E '\w+\s+overlay$' /etc/backup/installed_packages.txt | awk '{print $1}' | xargs apk add
+
+If you are using NethSecurity 8.7, use::
 
   opkg update
   grep -E '\w+\s+overlay$' /etc/backup/installed_packages.txt | awk '{print $1}' | xargs opkg install
@@ -81,3 +88,40 @@ Automatic package updates
 
 Automatic updates for packages can be enabled from the ``Update`` section under the ``System`` menu, by enabling the ``Automatic updates`` option.
 Updates are checked daily and, if available, they are automatically downloaded and installed.
+
+Package manager commands
+========================
+
+NethSecurity 8.8 uses ``apk``. NethSecurity 8.7 and earlier use ``opkg``.
+Use the following quick reference when translating older command examples:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 28 44
+
+   * - OPKG command
+     - APK equivalent
+     - Description
+   * - ``opkg install <pkg>``
+     - ``apk add <pkg>``
+     - Install a package
+   * - ``opkg remove <pkg>``
+     - ``apk del <pkg>``
+     - Remove a package
+   * - ``opkg upgrade``
+     - ``apk upgrade``
+     - Upgrade all packages
+   * - ``opkg files <pkg>``
+     - ``apk info -L <pkg>``
+     - List package contents
+   * - ``opkg list-installed``
+     - ``apk info``
+     - List installed packages
+   * - ``opkg update``
+     - ``apk update``
+     - Update package lists
+   * - ``opkg search <pkg>``
+     - ``apk search <pkg>``
+     - Search for packages
+
+The ``opkg find`` command used in a few older examples maps to ``apk search`` on NethSecurity 8.8.

--- a/updates.rst
+++ b/updates.rst
@@ -74,7 +74,7 @@ If you are running NethSecurity 8.8, use::
   apk update
   grep -E '\w+\s+overlay$' /etc/backup/installed_packages.txt | awk '{print $1}' | xargs apk add
 
-If you are running NethSecurity 8.7, use::
+If you are running NethSecurity 8.7 or older, use::
 
   opkg update
   grep -E '\w+\s+overlay$' /etc/backup/installed_packages.txt | awk '{print $1}' | xargs opkg install

--- a/ups.rst
+++ b/ups.rst
@@ -45,7 +45,7 @@ If you are running NethSecurity 8.8, use::
     apk update
     apk add nut-server nut-upsc nut-upsmon nut-upscmd
 
-If you are running NethSecurity 8.7 or older, use::
+If you are running NethSecurity 8.7.2 or older, use::
 
     opkg update
     opkg install nut-server nut-upsc nut-upsmon nut-upscmd
@@ -74,7 +74,7 @@ Step 2: setup the appropriate driver
 
       apk add nut-driver-usbhid-ups
 
-   If you are running NethSecurity 8.7 or older, use::
+   If you are running NethSecurity 8.7.2 or older, use::
 
       opkg install nut-driver-usbhid-ups
 
@@ -204,7 +204,7 @@ The secondary firewall will connect to the primary firewall and monitor the UPS 
        apk update
        apk add nut-upsc nut-upsmon
 
-   If you are running NethSecurity 8.7 or older, use::
+   If you are running NethSecurity 8.7.2 or older, use::
 
        opkg update
        opkg install nut-upsc nut-upsmon

--- a/ups.rst
+++ b/ups.rst
@@ -45,7 +45,7 @@ If you are running NethSecurity 8.8, use::
     apk update
     apk add nut-server nut-upsc nut-upsmon nut-upscmd
 
-If you are running NethSecurity 8.7, use::
+If you are running NethSecurity 8.7 or older, use::
 
     opkg update
     opkg install nut-server nut-upsc nut-upsmon nut-upscmd
@@ -74,7 +74,7 @@ Step 2: setup the appropriate driver
 
       apk add nut-driver-usbhid-ups
 
-   If you are running NethSecurity 8.7, use::
+   If you are running NethSecurity 8.7 or older, use::
 
       opkg install nut-driver-usbhid-ups
 
@@ -204,7 +204,7 @@ The secondary firewall will connect to the primary firewall and monitor the UPS 
        apk update
        apk add nut-upsc nut-upsmon
 
-   If you are running NethSecurity 8.7, use::
+   If you are running NethSecurity 8.7 or older, use::
 
        opkg update
        opkg install nut-upsc nut-upsmon

--- a/ups.rst
+++ b/ups.rst
@@ -38,7 +38,14 @@ Then, follow these steps:
 Step 1: install the required packages
 --------------------------------------
 
-Install the required packages::
+Install the required packages.
+
+If you are using NethSecurity 8.8, use::
+
+    apk update
+    apk add nut-server nut-upsc nut-upsmon nut-upscmd
+
+If you are using NethSecurity 8.7, use::
 
     opkg update
     opkg install nut-server nut-upsc nut-upsmon nut-upscmd
@@ -61,9 +68,15 @@ Step 2: setup the appropriate driver
 2. Select the driver from the `NUT driver page <https://networkupstools.org/stable-hcl.html>`_.
 
 3. All driver packages start with ``nut-driver-`` prefix. Some UPS models may require a specific driver, but most of them work with the ``usbhid-ups`` driver.
-   Install the selected driver package, in this case the ``usbhid-ups`` driver: ::
+   Install the selected driver package, in this case the ``usbhid-ups`` driver.
 
-    opkg install nut-driver-usbhid-ups
+   If you are using NethSecurity 8.8, use::
+
+      apk add nut-driver-usbhid-ups
+
+   If you are using NethSecurity 8.7, use::
+
+      opkg install nut-driver-usbhid-ups
 
 4. Set up the driver inside the ``upsd`` (nut-server) server. The nut-server will connect to the UPS using the driver and the port specified.
    It will monitor the UPS at regular intervals and provide the information to the clients like ``upsmon``. Execute: ::
@@ -184,10 +197,17 @@ Connect to remote NUT server
 This is the case where a secondary firewall is connected to the same UPS and the NUT server is running on the primary firewall.
 The secondary firewall will connect to the primary firewall and monitor the UPS status.
 
-1. First, install the NUT services on the client machine::
+1. First, install the NUT services on the client machine.
 
-    opkg update
-    opkg install nut-upsc nut-upsmon
+   If you are using NethSecurity 8.8, use::
+
+       apk update
+       apk add nut-upsc nut-upsmon
+
+   If you are using NethSecurity 8.7, use::
+
+       opkg update
+       opkg install nut-upsc nut-upsmon
 
    These packages are not preserved during a system upgrade. For more info see :ref:`restore_extra_packages-section`.
 

--- a/ups.rst
+++ b/ups.rst
@@ -40,12 +40,12 @@ Step 1: install the required packages
 
 Install the required packages.
 
-If you are using NethSecurity 8.8, use::
+If you are running NethSecurity 8.8, use::
 
     apk update
     apk add nut-server nut-upsc nut-upsmon nut-upscmd
 
-If you are using NethSecurity 8.7, use::
+If you are running NethSecurity 8.7, use::
 
     opkg update
     opkg install nut-server nut-upsc nut-upsmon nut-upscmd
@@ -70,11 +70,11 @@ Step 2: setup the appropriate driver
 3. All driver packages start with ``nut-driver-`` prefix. Some UPS models may require a specific driver, but most of them work with the ``usbhid-ups`` driver.
    Install the selected driver package, in this case the ``usbhid-ups`` driver.
 
-   If you are using NethSecurity 8.8, use::
+   If you are running NethSecurity 8.8, use::
 
       apk add nut-driver-usbhid-ups
 
-   If you are using NethSecurity 8.7, use::
+   If you are running NethSecurity 8.7, use::
 
       opkg install nut-driver-usbhid-ups
 
@@ -199,12 +199,12 @@ The secondary firewall will connect to the primary firewall and monitor the UPS 
 
 1. First, install the NUT services on the client machine.
 
-   If you are using NethSecurity 8.8, use::
+   If you are running NethSecurity 8.8, use::
 
        apk update
        apk add nut-upsc nut-upsmon
 
-   If you are using NethSecurity 8.7, use::
+   If you are running NethSecurity 8.7, use::
 
        opkg update
        opkg install nut-upsc nut-upsmon

--- a/wol.rst
+++ b/wol.rst
@@ -13,7 +13,14 @@ On NethSecurity, EtherWake is available in the official repositories but it is n
 Installation
 ------------
 
-Install the package with::
+Install the package with the commands that match your NethSecurity version.
+
+If you are using NethSecurity 8.8, use::
+
+    apk update
+    apk add etherwake
+
+If you are using NethSecurity 8.7, use::
 
     opkg update
     opkg install etherwake
@@ -37,4 +44,3 @@ The basic command is::
 Example::
 
     etherwake -i eth0 00:11:22:33:44:55
-

--- a/wol.rst
+++ b/wol.rst
@@ -15,12 +15,12 @@ Installation
 
 Install the package with the commands that match your NethSecurity version.
 
-If you are using NethSecurity 8.8, use::
+If you are running NethSecurity 8.8, use::
 
     apk update
     apk add etherwake
 
-If you are using NethSecurity 8.7, use::
+If you are running NethSecurity 8.7, use::
 
     opkg update
     opkg install etherwake

--- a/wol.rst
+++ b/wol.rst
@@ -20,7 +20,7 @@ If you are running NethSecurity 8.8, use::
     apk update
     apk add etherwake
 
-If you are running NethSecurity 8.7, use::
+If you are running NethSecurity 8.7 or older, use::
 
     opkg update
     opkg install etherwake

--- a/wol.rst
+++ b/wol.rst
@@ -20,7 +20,7 @@ If you are running NethSecurity 8.8, use::
     apk update
     apk add etherwake
 
-If you are running NethSecurity 8.7 or older, use::
+If you are running NethSecurity 8.7.2 or older, use::
 
     opkg update
     opkg install etherwake


### PR DESCRIPTION
## Summary

- document the `opkg` -> `apk` command shift across package-install docs
- add a quick reference table for common package-manager equivalents
- keep `dns_over_http.rst` unchanged as requested

## Updated docs

- `checkmk.rst`
- `install.rst`
- `logs.rst`
- `network.rst`
- `remote_access.rst`
- `updates.rst`
- `ups.rst`
- `wol.rst`
