### PR TITLE
docs: add firewall 'Don't track' action

### DIFF
--- a/firewall_rules.rst
+++ b/firewall_rules.rst
@@ -44,6 +44,8 @@ Fill in the following fields for the new rule:
   * ``Accept``: accept the network traffic.
   * ``Reject``: block the traffic and notify the sender host.
   * ``Drop``: block the traffic, packets are dropped and no notification is sent to the sender host.
+  * ``Don't track``: bypass connection tracking for matching traffic. This action is available only in
+    ``Forward rules`` and ``Input rules``, requires a source zone, and is not available in ``Output rules``.
 * ``Rule position``: decide whether to add the rule to the bottom or top of the rule list.
 * ``Logging``: indicate whether traffic matching this rule should be logged. The log entry will include the rule name as a prefix.
   By default, logging is limited to 1 entry per second. See the :ref:`logging-limits` section for instructions on changing this limit.


### PR DESCRIPTION
## Summary

Document the new firewall rule action added in NethSecurity issue #1617 and expose its UI limitations in the firewall rules section.

- add the `Don't track` action to the rules list
- note that it requires a source zone
- note that it is not available in `Output rules`

## References

- https://github.com/NethServer/nethsecurity/issues/1617
- https://github.com/NethServer/python3-nethsec/pull/127
- https://github.com/NethServer/nethsecurity-ui/pull/767
