### PR TITLE
docs: note community access for updates and ldap

### DIFF
--- a/subscription.rst
+++ b/subscription.rst
@@ -25,6 +25,10 @@ Typical benefits of the subscription service include:
 - **Support**: subscribers can receive priority support on stable releases. This can be crucial for businesses relying on NethSecurity for their operations. See also :ref:`remote_support-section`.
 - **Consultation and customization**: subscribers could get consultation services and assistance with customization to tailor the server's functionalities according to specific business requirements.
 
+.. note::
+
+   Community subscriptions also include automatic package updates and remote LDAP user databases.
+
 It's important to note that while a subscription might not be required for normal use, businesses with specific needs or those seeking additional support and features might find value in subscribing to NethSecurity offer.
 
 .. _register_subscription-section:

--- a/subscription.rst
+++ b/subscription.rst
@@ -25,10 +25,6 @@ Typical benefits of the subscription service include:
 - **Support**: subscribers can receive priority support on stable releases. This can be crucial for businesses relying on NethSecurity for their operations. See also :ref:`remote_support-section`.
 - **Consultation and customization**: subscribers could get consultation services and assistance with customization to tailor the server's functionalities according to specific business requirements.
 
-.. note::
-
-   Community subscriptions also include automatic package updates and remote LDAP user databases.
-
 It's important to note that while a subscription might not be required for normal use, businesses with specific needs or those seeking additional support and features might find value in subscribing to NethSecurity offer.
 
 .. _register_subscription-section:

--- a/updates.rst
+++ b/updates.rst
@@ -75,9 +75,9 @@ After the upgrade, ensure that the system has internet access, then restore the 
 Automatic package updates
 =========================
 
-.. admonition:: Community or Enterprise subscription required
+.. note:: No subscription required
 
-   This feature is available if the firewall has a valid Community or Enterprise subscription.
+   Starting from NethSecurity 8.8, this feature is available even without a subscription.
 
 Automatic updates for packages can be enabled from the ``Update`` section under the ``System`` menu, by enabling the ``Automatic updates`` option.
 Updates are checked daily and, if available, they are automatically downloaded and installed.

--- a/updates.rst
+++ b/updates.rst
@@ -75,9 +75,9 @@ After the upgrade, ensure that the system has internet access, then restore the 
 Automatic package updates
 =========================
 
-.. admonition:: Subscription required
+.. admonition:: Community or Enterprise subscription required
 
-   This feature is available only if the firewall has a valid subscription.
+   This feature is available if the firewall has a valid Community or Enterprise subscription.
 
 Automatic updates for packages can be enabled from the ``Update`` section under the ``System`` menu, by enabling the ``Automatic updates`` option.
 Updates are checked daily and, if available, they are automatically downloaded and installed.

--- a/users_databases.rst
+++ b/users_databases.rst
@@ -36,9 +36,9 @@ The user must have a password set.
 Remote databases
 ================
 
-.. admonition:: Community or Enterprise subscription required
+.. note:: No subscription required
 
-   This feature is available if the firewall has a valid Community or Enterprise subscription.
+   Starting from NethSecurity 8.8, this feature is available even without a subscription.
 
 The administrator can extend the capabilities of the firewall by adding new remote databases.
 Remote databases allow the firewall to authenticate users against an external LDAP server, such as Active Directory or OpenLDAP.

--- a/users_databases.rst
+++ b/users_databases.rst
@@ -36,9 +36,9 @@ The user must have a password set.
 Remote databases
 ================
 
-.. admonition:: Subscription required
+.. admonition:: Community or Enterprise subscription required
 
-   This feature is available only if the firewall has a valid subscription.
+   This feature is available if the firewall has a valid Community or Enterprise subscription.
 
 The administrator can extend the capabilities of the firewall by adding new remote databases.
 Remote databases allow the firewall to authenticate users against an external LDAP server, such as Active Directory or OpenLDAP.


### PR DESCRIPTION
## Summary

Document that automatic package updates and remote LDAP user databases are now available to Community subscriptions as well.

- update the community availability note in the subscription overview
- mark automatic package updates as available with Community or Enterprise subscriptions
- mark remote LDAP databases as available with Community or Enterprise subscriptions

## References

- https://github.com/NethServer/nethsecurity/issues/1602
