### PR TITLE
docs: update dhcp section to include support for multiple address ranges

### DIFF
--- a/dns_dhcp.rst
+++ b/dns_dhcp.rst
@@ -50,6 +50,12 @@ Available fields:
   * ``Range IP end`` : last IP address of DHCP range
   * ``Lease time`` :  lease time (default 1 hour)
 
+  Each DHCP server can serve more than one address range: under ``IP ranges`` you can specify multiple distinct IP ranges
+  for the same interface, each one defined by its own ``Range IP start`` and ``Range IP end``. Click :guilabel:`Add IP range`
+  to define an additional range, or use the trash icon next to a range to remove it. At least one range must be specified,
+  while the others are optional. Each range must belong to the interface network class, and the ``Range IP end`` must be
+  higher than the ``Range IP start``. Ranges are allowed to overlap.
+
 **DHCP Advanced settings**
 
 ``Force DHCP server start`` 

--- a/release_notes.rst
+++ b/release_notes.rst
@@ -22,6 +22,7 @@ Image version: `8.8.0-beta1` (based on OpenWrt 25.12.4)
 - Added Avahi (mDNS) package to the NethSecurity reposistory.
 - Added the firewall `DON'T TRACK` action.
 - Several features previously limited to subscription-based versions are now available in the Community edition.
+- Added support for multiple DHCP ranges directly in the UI, allowing for more flexible IP address allocation.
 
 .. rubric:: Improvements
 


### PR DESCRIPTION
This pull request updates the DHCP server documentation to clarify how multiple IP address ranges can be configured for a single interface. The main change is an added explanation of how to add, remove, and validate multiple IP ranges in the DHCP configuration.