### PR TITLE
docs: add geoblocking feature to threat shield ip documentation

### DIFF
--- a/release_notes.rst
+++ b/release_notes.rst
@@ -22,6 +22,7 @@ Image version: `8.8.0-beta1` (based on OpenWrt 25.12.4)
 - Added Avahi (mDNS) package to the NethSecurity reposistory.
 - Added the firewall `DON'T TRACK` action.
 - Several features previously limited to subscription-based versions are now available in the Community edition.
+- Added Geoblocking feature to Threat Shield IP, allowing users to block traffic from specific countries or regions.
 
 .. rubric:: Improvements
 

--- a/threat_shield_ip.rst
+++ b/threat_shield_ip.rst
@@ -135,6 +135,43 @@ Valid syntax for the address is the same as for the :ref:`local_allowlist-sectio
 When adding addresses to the local blocklist, ensure you enter them correctly to avoid accidentally blocking legitimate traffic.
 It's also a good practice to include a descriptive comment for each entry to help with future management and auditing of your blocklist.
 
+.. _geoblocking-section:
+
+Geoblocking
+-----------
+
+The ``Geoblocking`` tab allows you to block network traffic based on the geographic origin of the IP addresses,
+relying on country-based IP feeds. This is useful to keep out traffic coming from countries you never expect to
+interact with.
+
+The feature is disabled by default. To enable it, open the ``Geoblocking`` tab and turn on the ``Geo IP Blocking`` switch.
+Threat Shield IP must be enabled for geoblocking to work.
+
+Countries are organized into regions (Africa, Americas, Asia, Europe, Oceania and Others), each shown as a card
+reporting the number of currently blocked countries. Selecting a region displays the list of its countries, where you can:
+
+- block or allow individual countries using their checkbox;
+- use the :guilabel:`Block all` and :guilabel:`Allow all` buttons to act on the whole region at once;
+- filter the list by country name or by status (blocked / not blocked).
+
+Click :guilabel:`Save` to apply the configuration.
+
+.. warning:: Avoid blocking the regions where your own users are located, otherwise legitimate traffic may be dropped.
+
+Blocking direction
+^^^^^^^^^^^^^^^^^^
+
+By default, geoblocking only blocks **incoming** connections, i.e. traffic initiated from the selected countries
+towards your firewall and networks. Outgoing connections (traffic initiated by your local clients towards hosts in the
+selected countries) are still allowed.
+
+If you also want to block **outgoing** connections to the selected countries, add the ``country`` feed to the
+``ban_blockforwardlan`` property, which applies the feed to the LAN-forward chain. From the command line: ::
+
+  uci add_list banip.global.ban_blockforwardlan='country'
+  uci commit banip
+  /etc/init.d/banip restart
+
 .. _brute_force-section:
 
 Block brute force attacks


### PR DESCRIPTION
This pull request adds comprehensive documentation for the new Geoblocking feature in the Threat Shield IP documentation. The update explains how to enable and use the feature, describes its UI, and provides important usage notes and warnings. The documentation also covers how to configure blocking direction for both incoming and outgoing connections.