### PR TITLE
Update migration.md

### DIFF
--- a/docs/administrator-manual/migration.md
+++ b/docs/administrator-manual/migration.md
@@ -172,7 +172,7 @@ The following features are not migrated to NethSecurity:
 - **Bandwidth monitor** (ntopng): available in [Real-time monitoring](./monitoring/monitoring.md) and [Metrics](./system/controller.md)
 - **Fail2ban**: replaced by Threat Shield [brute force protection](./security/threat_shield_ip.md)
 - **Threat Shield DNS**: must be reconfigured manually — see [Threat Shield DNS](./security/threat_shield_dns.md)
-- **Custom templates** (`template-custom`): not migrated — this mechanism no longer exists in NethSecurity. The web interface now exposes far more configuration options than in NethServer 7, so check whether the same result can be achieved directly from the UI.
+- **Custom templates** (`template-custom`): not migrated — this mechanism no longer exists in NethSecurity. The web interface now exposes far more configuration options than in NethServer 7, so check whether the same result can be achieved directly from the UI. If you are unsure whether the same functionality is already present in NethSecurity, open a support ticket with Nethesis before proceeding with the migration.
 
 ## Custom Zones
 

--- a/docs/administrator-manual/migration.md
+++ b/docs/administrator-manual/migration.md
@@ -172,7 +172,7 @@ The following features are not migrated to NethSecurity:
 - **Bandwidth monitor** (ntopng): available in [Real-time monitoring](./monitoring/monitoring.md) and [Metrics](./system/controller.md)
 - **Fail2ban**: replaced by Threat Shield [brute force protection](./security/threat_shield_ip.md)
 - **Threat Shield DNS**: must be reconfigured manually — see [Threat Shield DNS](./security/threat_shield_dns.md)
-- **Custom templates** (`template-custom`): are not migrated. Verify whether they are still required in the new version and, if so, recreate them manually or, where supported, from the web interface.
+- **Custom templates** (`template-custom`): not migrated — this mechanism no longer exists in NethSecurity. The web interface now exposes far more configuration options than in NethServer 7, so check whether the same result can be achieved directly from the UI.
 
 ## Custom Zones
 

--- a/docs/administrator-manual/migration.md
+++ b/docs/administrator-manual/migration.md
@@ -172,6 +172,7 @@ The following features are not migrated to NethSecurity:
 - **Bandwidth monitor** (ntopng): available in [Real-time monitoring](./monitoring/monitoring.md) and [Metrics](./system/controller.md)
 - **Fail2ban**: replaced by Threat Shield [brute force protection](./security/threat_shield_ip.md)
 - **Threat Shield DNS**: must be reconfigured manually — see [Threat Shield DNS](./security/threat_shield_dns.md)
+- **Custom templates** (`template-custom`): are not migrated. Verify whether they are still required in the new version and, if so, recreate them manually or, where supported, from the web interface.
 
 ## Custom Zones
 

--- a/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/migration.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/migration.md
@@ -172,7 +172,7 @@ Le seguenti funzionalità non vengono migrate in NethSecurity:
 - **Monitor banda** (ntopng): disponibile nel [Monitoraggio in tempo reale](./monitoring/monitoring.md) e in [Metriche](./system/controller.md)
 - **Fail2ban**: sostituito da Threat Shield [protezione attacchi brute force](./security/threat_shield_ip.md)
 - **Threat Shield DNS**: deve essere riconfigurato manualmente — vedi [Threat Shield DNS](./security/threat_shield_dns.md)
-- **Template personalizzati** (`template-custom`): non migrati — questo meccanismo non esiste più in NethSecurity. L'interfaccia web espone ora molte più opzioni di configurazione rispetto a NethServer 7, quindi verifica se lo stesso risultato è ottenibile direttamente dall'interfaccia.
+- **Template personalizzati** (`template-custom`): non migrati — questo meccanismo non esiste più in NethSecurity. L'interfaccia web espone ora molte più opzioni di configurazione rispetto a NethServer 7, quindi verifica se lo stesso risultato è ottenibile direttamente dall'interfaccia. Se non sei sicuro che la stessa funzionalità sia già presente in NethSecurity, apri un ticket di supporto a Nethesis prima di procedere con la migrazione.
 
 ## Zone personalizzate
 

--- a/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/migration.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/migration.md
@@ -172,6 +172,7 @@ Le seguenti funzionalità non vengono migrate in NethSecurity:
 - **Monitor banda** (ntopng): disponibile nel [Monitoraggio in tempo reale](./monitoring/monitoring.md) e in [Metriche](./system/controller.md)
 - **Fail2ban**: sostituito da Threat Shield [protezione attacchi brute force](./security/threat_shield_ip.md)
 - **Threat Shield DNS**: deve essere riconfigurato manualmente — vedi [Threat Shield DNS](./security/threat_shield_dns.md)
+- **Template personalizzati** (`template-custom`): non migrati — questo meccanismo non esiste più in NethSecurity. L'interfaccia web espone ora molte più opzioni di configurazione rispetto a NethServer 7, quindi verifica se lo stesso risultato è ottenibile direttamente dall'interfaccia.
 
 ## Zone personalizzate
 


### PR DESCRIPTION
Added an entry for `template-custom` to clarify that custom templates are not migrated, should be reviewed for relevance in the new version, and recreated manually or through the web interface when supported.