### PR TITLE
docs(tutorial): add FTP passive mode guide

### DIFF
--- a/docs/tutorial/hosting-an-ftp-server-passive-mode.md
+++ b/docs/tutorial/hosting-an-ftp-server-passive-mode.md
@@ -1,0 +1,40 @@
+---
+title: "Hosting an FTP server in passive mode"
+sidebar_position: 8.5
+---
+
+# Hosting an FTP server in passive mode
+
+When you host an FTP server inside your LAN behind NethSecurity 8, external clients can fail to download files in passive mode by default.
+
+For security reasons, the firewall handles NAT dynamically and does not automatically track the random high ports requested by passive FTP connections.
+
+To allow passive FTP traffic, explicitly enable the Netfilter FTP connection tracking helper (`conntrack`) on the WAN zone.
+
+## Configuration steps
+
+1. Load the kernel modules from the **NAT helpers** page in the UI.
+
+   Make sure the required kernel modules for FTP tracking and NAT are loaded on the system:
+
+   ```text
+   nf_conntrack_ftp
+   nf_nat_ftp
+   ```
+
+2. Activate the FTP helper on the WAN zone.
+
+   Run these UCI commands over SSH to assign the FTP helper to the `ns_wan` interface and disable automatic helper assignment:
+
+   ```bash
+   uci set firewall.ns_wan.auto_helper='0'
+   uci set firewall.ns_wan.helper='ftp'
+   uci commit firewall
+   reload_config
+   ```
+
+## Migration from NethServer 7
+
+:::warning
+If you are migrating an existing setup from **NethServer 7**, step 1 is not required. On migrated firewalls, the helpers are enabled by default for compatibility.
+:::

--- a/docs/tutorial/hosting-an-ftp-server-passive-mode.md
+++ b/docs/tutorial/hosting-an-ftp-server-passive-mode.md
@@ -33,8 +33,6 @@ To allow passive FTP traffic, explicitly enable the Netfilter FTP connection tra
    reload_config
    ```
 
-## Migration from NethServer 7
-
-:::warning
+:::tip
 If you are migrating an existing setup from **NethServer 7**, step 1 is not required. On migrated firewalls, the helpers are enabled by default for compatibility.
 :::

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -18,6 +18,7 @@ This section collects focused how-to articles.
 - [DNS over HTTPS](./dns-over-https.md) — set up DNS over HTTPS with filtering for privacy-focused DNS
 - [Hardware RAID controller](./hardware-raid-controller-nethsecurity-8.md) — driver compatibility and workarounds for hardware RAID controllers
 - [High Availability (HA)](./high-availability-ha.md) — active/passive HA setup, support package, and upgrade from NethSecurity 7
+- [Hosting an FTP server in passive mode](./hosting-an-ftp-server-passive-mode.md) — allow passive FTP connections for a LAN server behind NethSecurity 8
 - [Installing on a VPS](./installing-nethsecurity-8-on-a-vps.md) — install NethSecurity on cloud providers that don't allow disk image uploads
 - [Network interface reorder after upgrade to 8.7.1](./network-interface-reorder-after-upgrade-8-7-1.md) — fix for network interface order changes after upgrade with mixed NIC vendors
 - [Registration troubleshooting](./registration-troubleshooting-nethsecurity-8.md) — diagnose and fix registration failures

--- a/i18n/it/docusaurus-plugin-content-docs/current/tutorial/hosting-an-ftp-server-passive-mode.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/tutorial/hosting-an-ftp-server-passive-mode.md
@@ -1,0 +1,40 @@
+---
+title: "Ospitare un server FTP in modalità passiva"
+sidebar_position: 8.5
+---
+
+# Ospitare un server FTP in modalità passiva
+
+Quando si ospita un server FTP all'interno della propria LAN dietro NethSecurity 8, i client esterni potrebbero non riuscire a scaricare file in modalità passiva per impostazione predefinita.
+
+Per motivi di sicurezza, il firewall gestisce il NAT in modo dinamico e non tiene traccia automaticamente delle porte alte casuali richieste dalle connessioni FTP in modalità passiva.
+
+Per consentire il traffico FTP in modalità passiva, è necessario abilitare esplicitamente l'helper di tracciamento delle connessioni FTP di Netfilter (`conntrack`) sulla zona WAN.
+
+## Passaggi di configurazione
+
+1. Caricare i moduli del kernel dalla pagina **NAT helpers** nell'interfaccia utente.
+
+   Assicurarsi che i moduli del kernel richiesti per il tracciamento FTP e il NAT siano caricati sul sistema:
+
+   ```text
+   nf_conntrack_ftp
+   nf_nat_ftp
+   ```
+
+2. Attivare l'helper FTP sulla zona WAN.
+
+   Eseguire questi comandi UCI tramite SSH per assegnare l'helper FTP all'interfaccia `ns_wan` e disabilitare l'assegnazione automatica degli helper:
+
+   ```bash
+   uci set firewall.ns_wan.auto_helper='0'
+   uci set firewall.ns_wan.helper='ftp'
+   uci commit firewall
+   reload_config
+   ```
+
+## Migrazione da NethServer 7
+
+:::warning
+Se si sta migrando una configurazione esistente da **NethServer 7**, il passaggio 1 non è necessario. Nei firewall migrati, gli helper sono abilitati per impostazione predefinita per garantire la compatibilità.
+:::

--- a/i18n/it/docusaurus-plugin-content-docs/current/tutorial/hosting-an-ftp-server-passive-mode.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/tutorial/hosting-an-ftp-server-passive-mode.md
@@ -33,8 +33,6 @@ Per consentire il traffico FTP in modalità passiva, è necessario abilitare esp
    reload_config
    ```
 
-## Migrazione da NethServer 7
-
-:::warning
+:::tip
 Se si sta migrando una configurazione esistente da **NethServer 7**, il passaggio 1 non è necessario. Nei firewall migrati, gli helper sono abilitati per impostazione predefinita per garantire la compatibilità.
 :::

--- a/i18n/it/docusaurus-plugin-content-docs/current/tutorial/index.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/tutorial/index.md
@@ -18,6 +18,7 @@ Questa sezione raccoglie articoli pratici mirati.
 - [DNS su HTTPS con filtraggio](./dns-over-https.md) — configura DNS over HTTPS con filtraggio per una configurazione DNS incentrata sulla privacy
 - [Controller RAID hardware](./hardware-raid-controller-nethsecurity-8.md) — compatibilità driver e soluzioni alternative per controller RAID hardware
 - [Alta affidabilità (HA)](./high-availability-ha.md) — configurazione HA attiva/passiva, pacchetto di supporto e upgrade da NethSecurity 7
+- [Hosting un server FTP in modalità passiva](./hosting-an-ftp-server-passive-mode.md) — consentire connessioni FTP passive per un server LAN dietro NethSecurity 8
 - [Installazione su VPS](./installing-nethsecurity-8-on-a-vps.md) — installa NethSecurity su provider cloud che non supportano il caricamento di immagini disco
 - [Spostamento schede di rete dopo aggiornamento a versione 8.7.1](./network-interface-reorder-after-upgrade-8-7-1.md) — fix per il riordino delle interfacce di rete dopo upgrade con NIC di produttori diversi
 - [Problema registrazione](./registration-troubleshooting-nethsecurity-8.md) — diagnostica e risolvi i problemi di registrazione


### PR DESCRIPTION
NethSecurity 8.7.2 kernel nat helper crashes when the NATed IP address digits count is higher than the original IP's. In this case, ftp passive mode will not permit download.
Possible workaround: change the FTP server address to a higher count if possible.

NethSecurity 8.8 kernel fixes the problem: passive mode always works with the setup described in the tutorial.
