### PR TITLE
Fix IP address example in Netmap documentation

### DIFF
--- a/docs/administrator-manual/firewall/nat.md
+++ b/docs/administrator-manual/firewall/nat.md
@@ -75,7 +75,7 @@ Let's use this translation scheme.
 - Network A: 192.168.1.0/24 -\> is translated to -\> Network ALT_A: 10.1.1.0/24
 - Network B: 192.168.1.0/24 -\> is translated to -\> Network ALT_B: 10.2.2.0/24
 
-A host in network A trying to reach a host in network B must not contact the real IP but its translated network (only the last octet remains the same). For example, the host 192.168.1.10 from the network A wanting to reach 192.168.0.20 in network B must contact the IP 10.2.2.20 instead. Before the request exits firewall FW-A, the source of the packet will be rewritten by FW-A to the ALT_IP 10.1.1.10 to eliminate every routing issue on network B. The inverse process will occur for the returning packets.
+A host in network A trying to reach a host in network B must not contact the real IP but its translated network (only the last octet remains the same). For example, the host 192.168.1.10 from the network A wanting to reach 192.168.1.20 in network B must contact the IP 10.2.2.20 instead. Before the request exits firewall FW-A, the source of the packet will be rewritten by FW-A to the ALT_IP 10.1.1.10 to eliminate every routing issue on network B. The inverse process will occur for the returning packets.
 
 **Solution** The problem can be solved by using netmap to translate the traffic to a different private network. This allows the traffic to be routed correctly.
 

--- a/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/firewall/nat.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/firewall/nat.md
@@ -75,7 +75,7 @@ Usiamo questo schema di traduzione.
 - Network A: 192.168.1.0/24 -> è tradotto a -> Network ALT_A: 10.1.1.0/24
 - Network B: 192.168.1.0/24 -> è tradotto a -> Network ALT_B: 10.2.2.0/24
 
-Un host nella rete A che cerca di raggiungere un host nella rete B non deve contattare l'IP reale ma la sua rete tradotta (solo l'ultimo ottetto rimane lo stesso). Ad esempio, l'host 192.168.1.10 dalla rete A che vuole raggiungere 192.168.0.20 nella rete B deve contattare l'IP 10.2.2.20 invece. Prima che la richiesta esca dal firewall FW-A, l'origine del pacchetto verrà riscritta da FW-A all'ALT_IP 10.1.1.10 per eliminare ogni problema di routing sulla rete B. Il processo inverso si verificherà per i pacchetti di ritorno.
+Un host nella rete A che cerca di raggiungere un host nella rete B non deve contattare l'IP reale ma la sua rete tradotta (solo l'ultimo ottetto rimane lo stesso). Ad esempio, l'host 192.168.1.10 dalla rete A che vuole raggiungere 192.168.1.20 nella rete B deve contattare l'IP 10.2.2.20 invece. Prima che la richiesta esca dal firewall FW-A, l'origine del pacchetto verrà riscritta da FW-A all'ALT_IP 10.1.1.10 per eliminare ogni problema di routing sulla rete B. Il processo inverso si verificherà per i pacchetti di ritorno.
 
 **Soluzione** Il problema può essere risolto utilizzando netmap per tradurre il traffico a una rete privata diversa. Ciò consente al traffico di essere instradato correttamente.
 


### PR DESCRIPTION
Corrected a typo in the example IP address in the Netmap documentation.