### PR TITLE
Add version reference documentation for NethSecurity

### DIFF
--- a/docs/administrator-manual/about/version_reference.md
+++ b/docs/administrator-manual/about/version_reference.md
@@ -7,21 +7,21 @@ sidebar_position: 3
 
 Each NethSecurity image is based on a specific OpenWrt version. The following table lists the publication date, OpenWrt base version, and support status of each NethSecurity release.
 
-| NethSecurity version | Published  | Base version | Support status | Support ends                                  |
-| -------------------- | ---------- | ------------ | -------------- | --------------------------------------------- |
-| 8.8.0-beta1          | 2026-06-25 | 25.12.4      | Prerelease     | Not applicable                                |
-| 8.7.2                | 2026-03-25 | 24.10.5      | Current        | After two newer stable releases are published |
-| 8.7.1                | 2025-10-30 | 24.10.3      | Previous       | When the next stable release is published     |
-| 8.7.0                | 2025-10-29 | 24.10.3      | End of life    | Not recorded                                   |
-| 8-24.10.0-ns.1.6.0   | 2025-06-30 | 24.10.0      | End of life    | Not recorded                                  |
-| 8-24.10.0-ns.1.5.1   | 2025-04-10 | 24.10.0      | End of life    | Not recorded                                  |
-| 8-24.10.0-ns.1.5.0   | 2025-04-08 | 24.10.0      | End of life    | Not recorded                                  |
-| 8-23.05.6-ns.1.4.1   | 2024-12-18 | 23.05.6      | End of life    | Not recorded                                  |
-| 8-23.05.5-ns.1.3.0   | 2024-10-17 | 23.05.5      | End of life    | Not recorded                                  |
-| 8-23.05.4-ns.1.2.0   | 2024-08-08 | 23.05.4      | End of life    | Not recorded                                  |
-| 8-23.05.3-ns.1.1.0   | 2024-07-05 | 23.05.3      | End of life    | Not recorded                                  |
-| 8-23.05.3-ns.1.0.1   | 2024-06-05 | 23.05.3      | End of life    | Not recorded                                  |
-| 8-23.05.3-ns.1.0.0   | 2024-05-22 | 23.05.3      | End of life    | Not recorded                                  |
+| NethSecurity version | Published  | Base version | Support status | 
+| -------------------- | ---------- | ------------ | -------------- | 
+| 8.8.0-beta1          | 2026-06-25 | 25.12.4      | Not supported  | 
+| 8.7.2                | 2026-03-25 | 24.10.5      | Current        | 
+| 8.7.1                | 2025-10-30 | 24.10.3      | Previous       | 
+| 8.7.0                | 2025-10-29 | 24.10.3      | End of life    | 
+| 8-24.10.0-ns.1.6.0   | 2025-06-30 | 24.10.0      | End of life    | 
+| 8-24.10.0-ns.1.5.1   | 2025-04-10 | 24.10.0      | End of life    | 
+| 8-24.10.0-ns.1.5.0   | 2025-04-08 | 24.10.0      | End of life    | 
+| 8-23.05.6-ns.1.4.1   | 2024-12-18 | 23.05.6      | End of life    | 
+| 8-23.05.5-ns.1.3.0   | 2024-10-17 | 23.05.5      | End of life    | 
+| 8-23.05.4-ns.1.2.0   | 2024-08-08 | 23.05.4      | End of life    | 
+| 8-23.05.3-ns.1.1.0   | 2024-07-05 | 23.05.3      | End of life    | 
+| 8-23.05.3-ns.1.0.1   | 2024-06-05 | 23.05.3      | End of life    | 
+| 8-23.05.3-ns.1.0.0   | 2024-05-22 | 23.05.3      | End of life    | 
 
 The **Current** release receives all applicable software and security updates and is covered by full technical support.
 
@@ -29,9 +29,6 @@ The **Previous** release receives compatible security updates until another stab
 
 **End of life** releases no longer receive software updates, security fixes, or backports.
 
-**Prerelease** versions, including beta and release candidate builds, are not covered by the support policy.
-
-**Not recorded** indicates that no formal end-of-support date is available for that historical release.
 
 The base version refers to the OpenWrt release used to build the NethSecurity image.
 

--- a/docs/administrator-manual/about/version_reference.md
+++ b/docs/administrator-manual/about/version_reference.md
@@ -5,26 +5,33 @@ sidebar_position: 3
 
 # Version reference
 
-NethSecurity is built on OpenWrt.
-Each NethSecurity image is based on a specific OpenWrt release, which provides the underlying operating system, kernel, network stack, and core packages.
+Each NethSecurity image is based on a specific OpenWrt version. The following table lists the publication date, OpenWrt base version, and support status of each NethSecurity release.
 
-The following table shows the OpenWrt version used by each NethSecurity release.
+| NethSecurity version | Published  | Base version | Support status | Support ends                                  |
+| -------------------- | ---------- | ------------ | -------------- | --------------------------------------------- |
+| 8.8.0-beta1          | 2026-06-25 | 25.12.4      | Prerelease     | Not applicable                                |
+| 8.7.2                | 2026-03-25 | 24.10.5      | Current        | After two newer stable releases are published |
+| 8.7.1                | 2025-10-30 | 24.10.3      | Previous       | When the next stable release is published     |
+| 8.7.0                | 2025-10-29 | 24.10.3      | End of life    | Not recorded                                   |
+| 8-24.10.0-ns.1.6.0   | 2025-06-30 | 24.10.0      | End of life    | Not recorded                                  |
+| 8-24.10.0-ns.1.5.1   | 2025-04-10 | 24.10.0      | End of life    | Not recorded                                  |
+| 8-24.10.0-ns.1.5.0   | 2025-04-08 | 24.10.0      | End of life    | Not recorded                                  |
+| 8-23.05.6-ns.1.4.1   | 2024-12-18 | 23.05.6      | End of life    | Not recorded                                  |
+| 8-23.05.5-ns.1.3.0   | 2024-10-17 | 23.05.5      | End of life    | Not recorded                                  |
+| 8-23.05.4-ns.1.2.0   | 2024-08-08 | 23.05.4      | End of life    | Not recorded                                  |
+| 8-23.05.3-ns.1.1.0   | 2024-07-05 | 23.05.3      | End of life    | Not recorded                                  |
+| 8-23.05.3-ns.1.0.1   | 2024-06-05 | 23.05.3      | End of life    | Not recorded                                  |
+| 8-23.05.3-ns.1.0.0   | 2024-05-22 | 23.05.3      | End of life    | Not recorded                                  |
 
-| NethSecurity version | OpenWrt version |
-| -------------------- | --------------- |
-| 8.8.0-beta3          | 25.12.5         |
-| 8.8.0-beta2          | 25.12.5         |
-| 8.8.0-beta1          | 25.12.4         |
-| 8.7.2                | 24.10.5         |
-| 8.7.1                | 24.10.3         |
-| 8.7.0                | 24.10.3         |
-| 8-24.10.0-ns.1.6.0   | 24.10.0         |
-| 8-24.10.0-ns.1.5.1   | 24.10.0         |
-| 8-24.10.0-ns.1.5.0   | 24.10.0         |
-| 8-23.05.6-ns.1.4.1   | 23.05.6         |
-| 8-23.05.5-ns.1.3.0   | 23.05.5         |
-| 8-23.05.4-ns.1.2.0   | 23.05.4         |
-| 8-23.05.3-ns.1.1.0   | 23.05.3         |
-| 8-23.05.3-ns.1.0.1   | 23.05.3         |
-| 8-23.05.3-ns.1.0.0   | 23.05.3         |
+The **Current** release receives all applicable software and security updates and is covered by full technical support.
+
+The **Previous** release receives compatible security updates until another stable version is published. Some fixes may require upgrading to the current release.
+
+**End of life** releases no longer receive software updates, security fixes, or backports.
+
+**Prerelease** versions, including beta and release candidate builds, are not covered by the support policy.
+
+**Not recorded** indicates that no formal end-of-support date is available for that historical release.
+
+The base version refers to the OpenWrt release used to build the NethSecurity image.
 

--- a/docs/administrator-manual/about/version_reference.md
+++ b/docs/administrator-manual/about/version_reference.md
@@ -1,0 +1,30 @@
+---
+title: "Version reference"
+sidebar_position: 3
+---
+
+# Version reference
+
+NethSecurity is built on OpenWrt.
+Each NethSecurity image is based on a specific OpenWrt release, which provides the underlying operating system, kernel, network stack, and core packages.
+
+The following table shows the OpenWrt version used by each NethSecurity release.
+
+| NethSecurity version | OpenWrt version |
+| -------------------- | --------------- |
+| 8.8.0-beta3          | 25.12.5         |
+| 8.8.0-beta2          | 25.12.5         |
+| 8.8.0-beta1          | 25.12.4         |
+| 8.7.2                | 24.10.5         |
+| 8.7.1                | 24.10.3         |
+| 8.7.0                | 24.10.3         |
+| 8-24.10.0-ns.1.6.0   | 24.10.0         |
+| 8-24.10.0-ns.1.5.1   | 24.10.0         |
+| 8-24.10.0-ns.1.5.0   | 24.10.0         |
+| 8-23.05.6-ns.1.4.1   | 23.05.6         |
+| 8-23.05.5-ns.1.3.0   | 23.05.5         |
+| 8-23.05.4-ns.1.2.0   | 23.05.4         |
+| 8-23.05.3-ns.1.1.0   | 23.05.3         |
+| 8-23.05.3-ns.1.0.1   | 23.05.3         |
+| 8-23.05.3-ns.1.0.0   | 23.05.3         |
+

--- a/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/about/version_reference.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/about/version_reference.md
@@ -1,0 +1,31 @@
+# Riferimento delle versioni
+
+Ogni immagine di NethSecurity si basa su una specifica versione di OpenWrt. La tabella seguente elenca la data di pubblicazione, la versione base di OpenWrt e lo stato di supporto di ciascuna release di NethSecurity.
+
+| Versione NethSecurity | Pubblicata  | Versione base | Stato di supporto | Fine del supporto                             |
+| ---------------------- | ----------- | ------------- | ----------------- | --------------------------------------------- |
+| 8.8.0-beta1           | 2026-06-25  | 25.12.4       | Prerelease        | Non applicabile                               |
+| 8.7.2                 | 2026-03-25  | 24.10.5       | Corrente          | Dopo la pubblicazione di due nuove release stabili |
+| 8.7.1                 | 2025-10-30  | 24.10.3       | Precedente        | Quando viene pubblicata la prossima release stabile |
+| 8.7.0                 | 2025-10-29  | 24.10.3       | Fine del ciclo di vita | Non registrato                                |
+| 8-24.10.0-ns.1.6.0    | 2025-06-30  | 24.10.0       | Fine del ciclo di vita | Non registrato                                |
+| 8-24.10.0-ns.1.5.1    | 2025-04-10  | 24.10.0       | Fine del ciclo di vita | Non registrato                                |
+| 8-24.10.0-ns.1.5.0    | 2025-04-08  | 24.10.0       | Fine del ciclo di vita | Non registrato                                |
+| 8-23.05.6-ns.1.4.1    | 2024-12-18  | 23.05.6       | Fine del ciclo di vita | Non registrato                                |
+| 8-23.05.5-ns.1.3.0    | 2024-10-17  | 23.05.5       | Fine del ciclo di vita | Non registrato                                |
+| 8-23.05.4-ns.1.2.0    | 2024-08-08  | 23.05.4       | Fine del ciclo di vita | Non registrato                                |
+| 8-23.05.3-ns.1.1.0    | 2024-07-05  | 23.05.3       | Fine del ciclo di vita | Non registrato                                |
+| 8-23.05.3-ns.1.0.1    | 2024-06-05  | 23.05.3       | Fine del ciclo di vita | Non registrato                                |
+| 8-23.05.3-ns.1.0.0    | 2024-05-22  | 23.05.3       | Fine del ciclo di vita | Non registrato                                |
+
+La release **Corrente** riceve tutti gli aggiornamenti software e di sicurezza applicabili ed è coperta da supporto tecnico completo.
+
+La release **Precedente** riceve aggiornamenti di sicurezza compatibili fino alla pubblicazione di un'altra versione stabile. Alcune correzioni potrebbero richiedere l'aggiornamento alla release corrente.
+
+Le release **Fine del ciclo di vita** non ricevono più aggiornamenti software, correzioni di sicurezza o backport.
+
+Le versioni **Prerelease**, inclusi build beta e release candidate, non sono coperte dalla politica di supporto.
+
+**Non registrato** indica che non è disponibile una data formale di fine supporto per quella release storica.
+
+La versione base si riferisce alla release di OpenWrt utilizzata per costruire l'immagine di NethSecurity.

--- a/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/about/version_reference.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/about/version_reference.md
@@ -2,30 +2,28 @@
 
 Ogni immagine di NethSecurity si basa su una specifica versione di OpenWrt. La tabella seguente elenca la data di pubblicazione, la versione base di OpenWrt e lo stato di supporto di ciascuna release di NethSecurity.
 
-| Versione NethSecurity | Pubblicata  | Versione base | Stato di supporto | Fine del supporto                             |
-| ---------------------- | ----------- | ------------- | ----------------- | --------------------------------------------- |
-| 8.8.0-beta1           | 2026-06-25  | 25.12.4       | Prerelease        | Non applicabile                               |
-| 8.7.2                 | 2026-03-25  | 24.10.5       | Corrente          | Dopo la pubblicazione di due nuove release stabili |
-| 8.7.1                 | 2025-10-30  | 24.10.3       | Precedente        | Quando viene pubblicata la prossima release stabile |
-| 8.7.0                 | 2025-10-29  | 24.10.3       | Fine del ciclo di vita | Non registrato                                |
-| 8-24.10.0-ns.1.6.0    | 2025-06-30  | 24.10.0       | Fine del ciclo di vita | Non registrato                                |
-| 8-24.10.0-ns.1.5.1    | 2025-04-10  | 24.10.0       | Fine del ciclo di vita | Non registrato                                |
-| 8-24.10.0-ns.1.5.0    | 2025-04-08  | 24.10.0       | Fine del ciclo di vita | Non registrato                                |
-| 8-23.05.6-ns.1.4.1    | 2024-12-18  | 23.05.6       | Fine del ciclo di vita | Non registrato                                |
-| 8-23.05.5-ns.1.3.0    | 2024-10-17  | 23.05.5       | Fine del ciclo di vita | Non registrato                                |
-| 8-23.05.4-ns.1.2.0    | 2024-08-08  | 23.05.4       | Fine del ciclo di vita | Non registrato                                |
-| 8-23.05.3-ns.1.1.0    | 2024-07-05  | 23.05.3       | Fine del ciclo di vita | Non registrato                                |
-| 8-23.05.3-ns.1.0.1    | 2024-06-05  | 23.05.3       | Fine del ciclo di vita | Non registrato                                |
-| 8-23.05.3-ns.1.0.0    | 2024-05-22  | 23.05.3       | Fine del ciclo di vita | Non registrato                                |
+| Versione di NethSecurity | Pubblicata  | Versione base | Stato di supporto |  
+| ------------------------- | ----------- | ------------- | ----------------- |  
+| 8.8.0-beta1              | 2026-06-25  | 25.12.4       | Non supportata    |  
+| 8.7.2                    | 2026-03-25  | 24.10.5       | Corrente          |  
+| 8.7.1                    | 2025-10-30  | 24.10.3       | Precedente        |  
+| 8.7.0                    | 2025-10-29  | 24.10.3       | Fine del supporto |  
+| 8-24.10.0-ns.1.6.0       | 2025-06-30  | 24.10.0       | Fine del supporto |  
+| 8-24.10.0-ns.1.5.1       | 2025-04-10  | 24.10.0       | Fine del supporto |  
+| 8-24.10.0-ns.1.5.0       | 2025-04-08  | 24.10.0       | Fine del supporto |  
+| 8-23.05.6-ns.1.4.1       | 2024-12-18  | 23.05.6       | Fine del supporto |  
+| 8-23.05.5-ns.1.3.0       | 2024-10-17  | 23.05.5       | Fine del supporto |  
+| 8-23.05.4-ns.1.2.0       | 2024-08-08  | 23.05.4       | Fine del supporto |  
+| 8-23.05.3-ns.1.1.0       | 2024-07-05  | 23.05.3       | Fine del supporto |  
+| 8-23.05.3-ns.1.0.1       | 2024-06-05  | 23.05.3       | Fine del supporto |  
+| 8-23.05.3-ns.1.0.0       | 2024-05-22  | 23.05.3       | Fine del supporto |
 
 La release **Corrente** riceve tutti gli aggiornamenti software e di sicurezza applicabili ed è coperta da supporto tecnico completo.
 
 La release **Precedente** riceve aggiornamenti di sicurezza compatibili fino alla pubblicazione di un'altra versione stabile. Alcune correzioni potrebbero richiedere l'aggiornamento alla release corrente.
 
-Le release **Fine del ciclo di vita** non ricevono più aggiornamenti software, correzioni di sicurezza o backport.
+Le release **Fine del supporto** non ricevono più aggiornamenti software, correzioni di sicurezza o backport.
 
 Le versioni **Prerelease**, inclusi build beta e release candidate, non sono coperte dalla politica di supporto.
-
-**Non registrato** indica che non è disponibile una data formale di fine supporto per quella release storica.
 
 La versione base si riferisce alla release di OpenWrt utilizzata per costruire l'immagine di NethSecurity.


### PR DESCRIPTION
This document provides a reference for the versions of NethSecurity and their corresponding OpenWrt releases.