### PR TITLE
Add release metadata to Download page

### DIFF
--- a/docs/administrator-manual/about/update_and_support_policy.md
+++ b/docs/administrator-manual/about/update_and_support_policy.md
@@ -41,7 +41,6 @@ Versions older than the previous version do not receive new software updates, se
 
 See the [Download](../installation/download.mdx) page for the support status of each published release.
 
-
 ## Requirements for Nethesis technical support
 
 :::note

--- a/docs/administrator-manual/about/update_and_support_policy.md
+++ b/docs/administrator-manual/about/update_and_support_policy.md
@@ -39,6 +39,8 @@ Upgrading to the current version is therefore recommended and may become mandato
 
 Versions older than the previous version do not receive new software updates, security fixes, or backports.
 
+See the [Download](../installation/download.mdx) page for the support status of each published release.
+
 
 ## Requirements for Nethesis technical support
 

--- a/docs/administrator-manual/installation/download.mdx
+++ b/docs/administrator-manual/installation/download.mdx
@@ -25,6 +25,13 @@ You can use the [package browser](pathname:///packages/) to explore all availabl
 
 The tables below list the available releases along with their respective download links.
 
+Each release is also tagged with a support status:
+
+- **Supported** — the release receives all applicable software and security updates and is covered by full technical support.
+- **Limited** — the release receives compatible security updates until another stable version is published. Some fixes may require upgrading to the current release.
+- **End of life** — the release no longer receives software updates, security fixes, or backports.
+- **Not supported** — staging and development releases are pre-release builds not intended for production use.
+
 ## Stable releases
 
 <StableReleases />
@@ -36,5 +43,7 @@ Staging releases are pre-release builds shipped ahead of a stable release, such 
 <StagingReleases />
 
 ## Development releases
+
+All development releases are not supported.
 
 <DevReleases />

--- a/docs/administrator-manual/installation/download.mdx
+++ b/docs/administrator-manual/installation/download.mdx
@@ -25,7 +25,7 @@ You can use the [package browser](pathname:///packages/) to explore all availabl
 
 The tables below list the available releases along with their respective download links.
 
-Each release is also tagged with a support status:
+Each release is also tagged with a support status (see the [update and support policy](../about/update_and_support_policy.md) for full details):
 
 - **Supported** — the release receives all applicable software and security updates and is covered by full technical support.
 - **Limited** — the release receives compatible security updates until another stable version is published. Some fixes may require upgrading to the current release.

--- a/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/about/update_and_support_policy.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/about/update_and_support_policy.md
@@ -53,7 +53,6 @@ Per qualificarsi per il **supporto completo**, il sistema deve:
 
 * eseguire la versione corrente
 * avere installati tutti gli aggiornamenti software disponibili
-* rispettare eventuali istruzioni di aggiornamento pubblicate da NethSecurity
 
 I sistemi che eseguono la versione precedente possono qualificarsi solo per il **supporto limitato**, alle condizioni descritte nella sezione pertinente.
 

--- a/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/about/update_and_support_policy.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/about/update_and_support_policy.md
@@ -7,18 +7,18 @@ sidebar_position: 3
 
 NethSecurity fornisce due principali metodi di aggiornamento:
 
-* **Aggiornamenti dei pacchetti software**, distribuiti regolarmente e installati senza sostituire l'intera immagine di sistema
-* **Aggiornamenti della versione di sistema**, eseguiti sostituendo l'intera immagine di sistema. Questi aggiornamenti includono modifiche alla piattaforma sottostante, richiedono un riavvio del sistema e vengono normalmente rilasciati ogni **4-6 mesi**
+* **Aggiornamenti dei pacchetti software**, distribuiti regolarmente e installati senza sostituire l'intera immagine del sistema
+* **Aggiornamenti della versione del sistema**, eseguiti sostituendo l'intera immagine del sistema. Questi aggiornamenti includono modifiche alla piattaforma sottostante, richiedono un riavvio del sistema e vengono normalmente rilasciati ogni **4-6 mesi**
 
 Le correzioni di sicurezza vengono fornite utilizzando il metodo di aggiornamento più appropriato, a seconda del componente interessato, dell'impatto della vulnerabilità e dei requisiti di stabilità del sistema.
 
-Quando una correzione non può essere applicata in sicurezza tramite un aggiornamento standard del pacchetto, potrebbe essere necessario installare una nuova versione del sistema. In caso di vulnerabilità critiche o sfruttate attivamente, una nuova immagine di sistema potrebbe essere rilasciata prima del previsto.
+Quando una correzione non può essere applicata in sicurezza tramite un aggiornamento standard del pacchetto, potrebbe essere necessario installare una nuova versione del sistema. In caso di vulnerabilità critiche o sfruttate attivamente, una nuova immagine del sistema potrebbe essere rilasciata prima del previsto.
 
 ## Livelli di supporto delle versioni di NethSecurity
 
 ### Versione corrente - supporto completo
 
-La versione corrente corrisponde all'ultima immagine di sistema pubblicata ed è consigliata per:
+La versione corrente corrisponde all'ultima immagine del sistema pubblicata ed è raccomandata per:
 
 * nuove installazioni
 * aggiornamenti di sistemi esistenti
@@ -29,11 +29,11 @@ La versione corrente riceve tutti gli aggiornamenti software applicabili.
 
 ### Versione precedente - supporto limitato
 
-La versione immediatamente precedente alla versione corrente rimane supportata, con supporto limitato, fino al rilascio della versione successiva a quella corrente. Basandosi sul consueto programma di rilascio delle immagini, questo periodo è generalmente compreso tra **4 e 6 mesi**.
+La versione immediatamente precedente alla versione corrente rimane supportata, con supporto limitato, fino al rilascio della versione successiva a quella corrente. In base al consueto programma di rilascio delle immagini, questo periodo è generalmente compreso tra **4 e 6 mesi**.
 
 Durante questo periodo, la versione precedente continua a ricevere solo aggiornamenti di sicurezza compatibili. Alcune correzioni potrebbero comunque richiedere un aggiornamento alla versione corrente.
 
-Pertanto, si consiglia di aggiornare alla versione corrente, che potrebbe diventare obbligatoria a causa di specifici requisiti tecnici o di sicurezza.
+Pertanto, si raccomanda di aggiornare alla versione corrente, che potrebbe diventare obbligatoria a causa di specifici requisiti tecnici o di sicurezza.
 
 ### Versioni precedenti - non supportate
 
@@ -43,20 +43,20 @@ Le versioni più vecchie della versione precedente non ricevono nuovi aggiorname
 
 :::note
 
-Il supporto tecnico di Nethesis è un servizio a pagamento disponibile solo per i sistemi coperti da un abbonamento valido. I livelli di supporto descritti in questa sezione si applicano quindi solo ai clienti con un abbonamento attivo.
+Il supporto tecnico di Nethesis è un servizio a pagamento disponibile solo per i sistemi coperti da un abbonamento valido. I livelli di supporto descritti in questa sezione si applicano quindi esclusivamente ai clienti con un abbonamento attivo.
 
 :::
 
 Per qualificarsi per il **supporto completo**, il sistema deve:
 
 * eseguire la versione corrente
-* avere installato tutti gli aggiornamenti software disponibili
+* avere installati tutti gli aggiornamenti software disponibili
 * rispettare eventuali istruzioni di aggiornamento pubblicate da NethSecurity
 
 I sistemi che eseguono la versione precedente possono qualificarsi solo per il **supporto limitato**, alle condizioni descritte nella sezione pertinente.
 
 Le versioni più vecchie della versione precedente non sono coperte dal supporto standard. Potrebbe essere necessario un aggiornamento a una versione supportata prima che possano essere fornite ulteriori attività di supporto.
 
-Un abbonamento valido non implica che una specifica versione possa essere mantenuta indefinitamente senza aggiornamenti.
+Un abbonamento valido non implica che una versione specifica possa essere mantenuta indefinitamente senza aggiornamenti.
 
-Per mantenere livelli adeguati di sicurezza, stabilità e compatibilità, sia gli aggiornamenti dei pacchetti software che le nuove versioni di sistema devono essere installati regolarmente e entro la finestra di aggiornamento applicabile.
+Per mantenere livelli adeguati di sicurezza, stabilità e compatibilità, sia gli aggiornamenti dei pacchetti software che le nuove versioni del sistema devono essere installati regolarmente e entro la finestra di aggiornamento applicabile.

--- a/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/about/update_and_support_policy.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/about/update_and_support_policy.md
@@ -39,6 +39,8 @@ Pertanto, si raccomanda di aggiornare alla versione corrente, che potrebbe diven
 
 Le versioni più vecchie della versione precedente non ricevono nuovi aggiornamenti software, correzioni di sicurezza o backport.
 
+Consulta la pagina [Download](../installation/download.mdx) per lo stato di supporto di ogni versione pubblicata.
+
 ## Requisiti per il supporto tecnico di Nethesis
 
 :::note

--- a/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/installation/download.mdx
+++ b/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/installation/download.mdx
@@ -3,7 +3,7 @@ title: Download
 sidebar_position: 2
 ---
 
-import {StableReleases, DevReleases, ImageVerifyCommand} from '@site/src/components/DownloadTable';
+import {StableReleases, StagingReleases, DevReleases, ImageVerifyCommand} from '@site/src/components/DownloadTable';
 
 # Download {#download-section}
 
@@ -25,10 +25,25 @@ Puoi usare il [browser dei pacchetti](pathname:///packages/) per esplorare tutte
 
 Le tabelle sottostanti elencano le versioni disponibili insieme ai rispettivi link di download.
 
+Ogni versione è inoltre contrassegnata con uno stato di supporto:
+
+- **Supported** — la versione riceve tutti gli aggiornamenti software e di sicurezza applicabili ed è coperta da supporto tecnico completo.
+- **Limited** — la versione riceve aggiornamenti di sicurezza compatibili fino alla pubblicazione di un'altra versione stabile. Alcune correzioni potrebbero richiedere l'aggiornamento alla versione corrente.
+- **End of life** — la versione non riceve più aggiornamenti software, correzioni di sicurezza o backport.
+- **Not supported** — le versioni staging e di sviluppo sono build pre-release non destinate all'uso in produzione.
+
 ## Versioni stabili
 
 <StableReleases />
 
+## Versioni staging
+
+Le versioni staging sono build pre-release pubblicate prima di una versione stabile, come immagini beta e release candidate (RC). Sono più stabili delle build di sviluppo ma non ancora consigliate per l'uso in produzione.
+
+<StagingReleases />
+
 ## Versioni di sviluppo
+
+Tutte le versioni di sviluppo non sono supportate.
 
 <DevReleases />

--- a/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/installation/download.mdx
+++ b/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/installation/download.mdx
@@ -25,7 +25,7 @@ Puoi usare il [browser dei pacchetti](pathname:///packages/) per esplorare tutte
 
 Le tabelle sottostanti elencano le versioni disponibili insieme ai rispettivi link di download.
 
-Ogni versione è inoltre contrassegnata con uno stato di supporto:
+Ogni versione è inoltre contrassegnata con uno stato di supporto (per i dettagli completi consulta la [politica di aggiornamento e supporto](../about/update_and_support_policy.md)):
 
 - **Supported** — la versione riceve tutti gli aggiornamenti software e di sicurezza applicabili ed è coperta da supporto tecnico completo.
 - **Limited** — la versione riceve aggiornamenti di sicurezza compatibili fino alla pubblicazione di un'altra versione stabile. Alcune correzioni potrebbero richiedere l'aggiornamento alla versione corrente.

--- a/src/components/DownloadTable/index.tsx
+++ b/src/components/DownloadTable/index.tsx
@@ -1,8 +1,15 @@
 import type {ReactNode} from 'react';
 import {useVersionData} from '@site/src/hooks/useVersionData';
-import type {Release, VersionData} from '@site/src/hooks/useVersionData';
+import type {Release, SupportStatus, VersionData} from '@site/src/hooks/useVersionData';
 
-function ReleaseTable({rows}: {rows: Release[]}): ReactNode {
+const SUPPORT_STATUS_LABELS: Record<SupportStatus, string> = {
+  supported: 'Supported',
+  limited: 'Limited',
+  eol: 'End of life',
+  'not-supported': 'Not supported',
+};
+
+function ReleaseTable({rows, detailed = true}: {rows: Release[]; detailed?: boolean}): ReactNode {
   if (!rows || rows.length === 0) {
     return <p>No releases available.</p>;
   }
@@ -10,7 +17,14 @@ function ReleaseTable({rows}: {rows: Release[]}): ReactNode {
     <table>
       <thead>
         <tr>
-          <th>Version</th>
+          <th>NethSecurity version</th>
+          {detailed && (
+            <>
+              <th>Published</th>
+              <th>OpenWrt version</th>
+              <th>Support status</th>
+            </>
+          )}
           <th>Image</th>
           <th>Hash</th>
           <th>SBOM</th>
@@ -20,6 +34,13 @@ function ReleaseTable({rows}: {rows: Release[]}): ReactNode {
         {rows.map((r) => (
           <tr key={r.version}>
             <td>{r.version}</td>
+            {detailed && (
+              <>
+                <td>{r.publishedDate ?? '–'}</td>
+                <td>{r.openwrtVersion ?? '–'}</td>
+                <td>{SUPPORT_STATUS_LABELS[r.supportStatus]}</td>
+              </>
+            )}
             <td>
               <a href={r.imageUrl}>x86-64</a>
             </td>
@@ -52,7 +73,7 @@ export function DevReleases(): ReactNode {
   const {data, loading, error} = useVersionData();
   if (loading) return <p>Loading releases…</p>;
   if (error) return <p>Could not load releases: {error}</p>;
-  return <ReleaseTable rows={data?.dev ?? []} />;
+  return <ReleaseTable rows={data?.dev ?? []} detailed={false} />;
 }
 
 // Renders any shell command that needs live version data.

--- a/src/hooks/useVersionData.ts
+++ b/src/hooks/useVersionData.ts
@@ -3,12 +3,18 @@ import {useState, useEffect} from 'react';
 const BASE_URL = 'https://updates.nethsecurity.nethserver.org';
 const S3_ENDPOINT = 'https://ams3.digitaloceanspaces.com';
 const BUCKET = 'nethsecurity';
+const TARGET = 'targets/x86/64';
+
+export type SupportStatus = 'supported' | 'limited' | 'eol' | 'not-supported';
 
 export type Release = {
   version: string;
   imageUrl: string;
   hashUrl: string;
   sbomUrl: string;
+  openwrtVersion: string | null;
+  publishedDate: string | null;
+  supportStatus: SupportStatus;
 };
 
 export type VersionData = {
@@ -40,16 +46,18 @@ function imageName(version: string): string {
 }
 
 function makeImageUrl(prefix: string, version: string): string {
-  return `${BASE_URL}/${prefix}/${version}/targets/x86/64/${imageName(version)}`;
+  return `${BASE_URL}/${prefix}/${version}/${TARGET}/${imageName(version)}`;
 }
 
 function makeHashUrl(prefix: string, version: string): string {
-  return `${BASE_URL}/${prefix}/${version}/targets/x86/64/sha256sums`;
+  return `${BASE_URL}/${prefix}/${version}/${TARGET}/sha256sums`;
 }
 
 function makeSbomUrl(prefix: string, version: string): string {
-  return `${BASE_URL}/${prefix}/${version}/targets/x86/64/nethsecurity-${version}-x86-64-generic.bom.cdx.json`;
+  return `${BASE_URL}/${prefix}/${version}/${TARGET}/nethsecurity-${version}-x86-64-generic.bom.cdx.json`;
 }
+
+// --- Dev releases: naming scheme is unrelated to stable/staging, left as-is. ---
 
 function parseVersion(tag: string): ParsedVersion | null {
   const m = /^(\d+)\.(\d+)\.(\d+)(?:-([^-]+))?(?:-(\d+)-g[0-9a-f]+)?$/.exec(tag);
@@ -91,6 +99,83 @@ function compareVersions(a: string, b: string): number {
   return b.localeCompare(a);
 }
 
+// --- Stable/staging releases: two real naming schemes, both starting with "8". ---
+// Legacy: 8-<openwrt-version>-ns.<build>            e.g. 8-23.05.3-ns.1.1.0
+// Current: 8.<minor>.<patch>[-beta.<n>]             e.g. 8.7.2, 8.8.0-beta.3
+// The bucket also contains bogus bare OpenWrt-version pointer folders (e.g. "23.05.3",
+// "24.10.0") that are not real releases - they don't start with "8" and are excluded below.
+
+const LEGACY_RE = /^8-(\d+\.\d+\.\d+)-ns\.(\d+)\.(\d+)\.(\d+)$/;
+const CURRENT_RE = /^8\.(\d+)\.(\d+)(?:-beta\.(\d+))?$/;
+
+function releaseSortKey(version: string): number[] {
+  const legacy = LEGACY_RE.exec(version);
+  if (legacy) {
+    const owrt = legacy[1].split('.').map(Number);
+    const build = [Number(legacy[2]), Number(legacy[3]), Number(legacy[4])];
+    return [0, ...owrt, ...build];
+  }
+
+  const current = CURRENT_RE.exec(version);
+  if (current) {
+    const minor = Number(current[1]);
+    const patch = Number(current[2]);
+    const betaNum = current[3] ? Number(current[3]) : null;
+    const isFinal = betaNum === null ? 1 : 0;
+    return [1, minor, patch, isFinal, betaNum ?? 0];
+  }
+
+  return [-1];
+}
+
+function compareReleaseKeys(a: number[], b: number[]): number {
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    const av = a[i] ?? 0;
+    const bv = b[i] ?? 0;
+    if (av !== bv) return bv - av;
+  }
+  return 0;
+}
+
+async function resolveReleaseMeta(
+  prefix: string,
+  version: string,
+): Promise<{openwrtVersion: string | null; publishedDate: string | null}> {
+  const legacy = LEGACY_RE.exec(version);
+  const url = `${BASE_URL}/${prefix}/${version}/${TARGET}/profiles.json`;
+
+  try {
+    if (legacy) {
+      // OpenWrt version is embedded in the folder name; only need Last-Modified.
+      const res = await fetch(url, {method: 'HEAD'});
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      return {
+        openwrtVersion: legacy[1],
+        publishedDate: formatDateOnly(res.headers.get('last-modified')),
+      };
+    }
+
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const profile = await res.json();
+    const stripped = (profile.version_code || '').replace(/^v/, '');
+    const openwrtVersion = /^\d+\.\d+\.\d+$/.test(stripped) ? stripped : null;
+    return {
+      openwrtVersion,
+      publishedDate: formatDateOnly(res.headers.get('last-modified')),
+    };
+  } catch {
+    return {openwrtVersion: null, publishedDate: null};
+  }
+}
+
+function formatDateOnly(lastModified: string | null): string | null {
+  if (!lastModified) return null;
+  const date = new Date(lastModified);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString().slice(0, 10);
+}
+
 async function listReleaseFolders(prefix: string): Promise<string[]> {
   const url =
     `${S3_ENDPOINT}/${BUCKET}?list-type=2&delimiter=/&prefix=` +
@@ -108,24 +193,57 @@ async function listReleaseFolders(prefix: string): Promise<string[]> {
   return folders;
 }
 
-function buildRows(prefix: string, versions: string[]): Release[] {
-  return versions.map((v) => {
-    const parsed = parseVersion(v);
+function buildLinks(prefix: string, version: string, hasSbom: boolean) {
+  return {
+    imageUrl: makeImageUrl(prefix, version),
+    hashUrl: makeHashUrl(prefix, version),
+    sbomUrl: hasSbom ? makeSbomUrl(prefix, version) : '',
+  };
+}
+
+async function collectDevReleases(): Promise<Release[]> {
+  let folders = await listReleaseFolders('dev');
+  folders = folders.filter((e) => e !== '24.10.0');
+  folders.sort(compareVersions);
+  return folders.map((version) => {
+    const parsed = parseVersion(version);
     const hasSbom = parsed != null && isNewScheme(parsed);
     return {
-      version: v,
-      imageUrl: makeImageUrl(prefix, v),
-      hashUrl: makeHashUrl(prefix, v),
-      sbomUrl: hasSbom ? makeSbomUrl(prefix, v) : '',
+      version,
+      ...buildLinks('dev', version, hasSbom),
+      openwrtVersion: null,
+      publishedDate: null,
+      supportStatus: 'not-supported' as const,
     };
   });
 }
 
-async function collectReleases(prefix: string): Promise<string[]> {
-  let folders = await listReleaseFolders(prefix);
-  folders = folders.filter((e) => e !== '24.10.0');
-  folders.sort(compareVersions);
-  return folders;
+async function collectStableOrStagingReleases(
+  prefix: 'stable' | 'staging',
+): Promise<Release[]> {
+  const folders = await listReleaseFolders(prefix);
+  const versions = folders
+    .filter((entry) => /^8[.-]/.test(entry))
+    .sort((a, b) => compareReleaseKeys(releaseSortKey(a), releaseSortKey(b)));
+
+  const rows = await Promise.all(
+    versions.map(async (version, index) => {
+      const meta = await resolveReleaseMeta(prefix, version);
+      const hasSbom = CURRENT_RE.test(version);
+      const supportStatus: SupportStatus =
+        prefix === 'staging' ? 'not-supported' : index === 0 ? 'supported' : index === 1 ? 'limited' : 'eol';
+
+      return {
+        version,
+        ...buildLinks(prefix, version, hasSbom),
+        openwrtVersion: meta.openwrtVersion,
+        publishedDate: meta.publishedDate,
+        supportStatus,
+      };
+    }),
+  );
+
+  return rows;
 }
 
 let _cache: VersionData | null = null;
@@ -141,21 +259,18 @@ export function useVersionData(): UseVersionDataResult {
 
     async function load() {
       try {
-        const [versionText, stableFolders, stagingFolders, devFolders] = await Promise.all([
+        const [versionText, stable, staging, dev] = await Promise.all([
           // Degrade gracefully if latest_release has CORS issues.
           fetch(`${BASE_URL}/stable/latest_release`)
             .then((r) => (r.ok ? r.text() : ''))
             .catch(() => ''),
-          collectReleases('stable'),
-          collectReleases('staging'),
-          collectReleases('dev'),
+          collectStableOrStagingReleases('stable'),
+          collectStableOrStagingReleases('staging'),
+          collectDevReleases(),
         ]);
 
         if (cancelled) return;
 
-        const stable = buildRows('stable', stableFolders);
-        const staging = buildRows('staging', stagingFolders);
-        const dev = buildRows('dev', devFolders);
         const version = versionText.trim() || (stable[0]?.version ?? '');
         const image = version ? imageName(version) : '';
 


### PR DESCRIPTION
## Summary
Adds published date, OpenWrt version, and support status columns to each release row on the Download page (Stable/Staging/Dev), so readers can tell what's supported without a separate page. Dev releases keep only version and download links, with a note that they're always unsupported.