### PR TITLE
Update ups.md by removing package preservation note

### DIFF
--- a/docs/administrator-manual/advanced-cli/ups.md
+++ b/docs/administrator-manual/advanced-cli/ups.md
@@ -194,7 +194,6 @@ This is the case where a secondary firewall is connected to the same UPS and the
         opkg update
         opkg install nut-upsc nut-upsmon
 
-    These packages are not preserved during a system upgrade. For more info see [Restore extra packages](../system/updates.md#restore_extra_packages-section).
 
 2.  Then, configure the client to connect to the remote server:
 

--- a/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/advanced-cli/ups.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/advanced-cli/ups.md
@@ -194,8 +194,6 @@ Questo è il caso in cui un firewall secondario è collegato allo stesso UPS e i
         opkg update
         opkg install nut-upsc nut-upsmon
 
-    Questi pacchetti non vengono preservati durante un aggiornamento del sistema. Per ulteriori informazioni, consulta [Ripristina pacchetti extra](../system/updates.md#restore_extra_packages-section).
-
 2.  Quindi, configura il client per connettersi al server remoto:
 
         uci set nut_monitor.upsmon=upsmon


### PR DESCRIPTION
Removed a wrong note about package preservation during upgrades.
It can generate doubts, there is already a good note before about the packages and the fact they are preserved during upgrades.