### PR TITLE
Update HA maintenance upgrade instructions

### DIFF
--- a/docs/administrator-manual/high-availability/ha_maintenance_troubleshooting.md
+++ b/docs/administrator-manual/high-availability/ha_maintenance_troubleshooting.md
@@ -66,7 +66,7 @@ This command will establish an SSH connection to the secondary node using the SS
 
 ### Upgrade
 
-The secondary node does not receive system updates automatically because it does not have direct Internet access. To update the secondary node, you need to connect to the primary node and run the update command on the secondary node: :
+The secondary node does not receive system updates automatically because it does not have direct Internet access. To update the secondary node, you need to connect to the primary node and run the update command on the primary node itself:
 
     ns-ha-config upgrade-remote
 

--- a/docs/administrator-manual/high-availability/ha_overview_features_limitations.md
+++ b/docs/administrator-manual/high-availability/ha_overview_features_limitations.md
@@ -64,6 +64,7 @@ The HA cluster supports synchronization for a wide range of features, including:
 - Controller connection and subscription (ns-plug)
 - Active connections tracking (conntrackd)
 - Hotspot (dedalo) only on physical interfaces
+- Nethesis Cloud Log Manager
 
 ### WAN interface types and setups
 

--- a/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/high-availability/ha_maintenance_troubleshooting.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/high-availability/ha_maintenance_troubleshooting.md
@@ -66,7 +66,7 @@ Questo comando stabilirà una connessione SSH al nodo secondario utilizzando la 
 
 ### Aggiornamento
 
-Il nodo secondario non riceve gli aggiornamenti di sistema automaticamente perché non ha accesso diretto a Internet. Per aggiornare il nodo secondario, è necessario connettersi al nodo primario ed eseguire il comando di aggiornamento sul nodo secondario:
+Il nodo secondario non riceve gli aggiornamenti di sistema automaticamente perché non ha accesso diretto a Internet. Per aggiornare il nodo secondario, è necessario connettersi al nodo primario e da lì lanciare il comando di aggiornamento:
 
     ns-ha-config upgrade-remote
 

--- a/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/high-availability/ha_overview_features_limitations.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/high-availability/ha_overview_features_limitations.md
@@ -64,6 +64,7 @@ Il cluster HA supporta la sincronizzazione per un'ampia gamma di caratteristiche
 - Connessione del controller e sottoscrizione (ns-plug)
 - Tracciamento delle connessioni attive (conntrackd)
 - Hotspot (dedalo) solo su interfacce fisiche
+- Nethesis Cloud Log Manager
 
 ### Tipi di interfaccia WAN e configurazioni
 


### PR DESCRIPTION
Clarified instructions for updating the secondary node by specifying that the update command should be run on the primary node itself.